### PR TITLE
fix: ensure system messages precede user/assistant for DeepSeek/vLLM

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -319,7 +319,7 @@ async function handleTransformerEndpoint(
         }
       }
       if (systemMsgs.length > 0 && otherMsgs.length > 0) {
-        requestBody.messages = [...otherMsgs, ...systemMsgs];
+        requestBody.messages = [...systemMsgs, ...otherMsgs];
       }
     }
 

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -73,13 +73,21 @@ export class AnthropicTransformer implements Transformer {
 
     const requestMessages = JSON.parse(JSON.stringify(request.messages || []));
 
+    // First pass: push all system messages to ensure they come before user/assistant.
+    // DeepSeek + vLLM require [system, user] order; wrong order causes garbled output.
     requestMessages?.forEach((msg: any) => {
       if (msg.role === "system") {
         messages.push({
           role: "system",
           content: msg.content,
         });
-        return;
+      }
+    });
+
+    // Second pass: push user/assistant/tool messages in original order
+    requestMessages?.forEach((msg: any) => {
+      if (msg.role === "system") {
+        return; // Already handled in first pass
       }
 
       if (msg.role === "user" || msg.role === "assistant") {


### PR DESCRIPTION
OpenAI-compatible providers (DeepSeek V4, GLM) require messages in [system, user, assistant] order. CCR places system messages after user/assistant in two locations, causing garbled output.

Fix: swap message order in routes.ts and use two-pass iteration in anthropic.transformer.ts.