### PR TITLE
fix: ignore stale fallback model routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **忽略已删除模型的残留路由，防止健康池污染**: 运行中从 provider 配置删除某个模型后，路由和 fallback 路径中残留的 `provider,model` 字符串仍会被当作有效候选，反复请求失败后进入健康池（fail pool），导致无关的 fallback 模型也被跳过。现在 `resolveConfiguredModel` 对无法在当前 provider 注册表中匹配到的 `provider,model` 直接返回 `null`，主路由保留客户端原始 model 而非传递失效字符串；fallback 循环在尝试请求前即校验模型是否存在于 provider 配置，跳过不存在的候选；`ProviderHealthStore` 所有公开方法统一在 `getKey` 层拦截空 provider/model，防止 `",model"` 等畸形 key 污染池数据。同时修复 fallback catch 块与成功路径使用不同变量（raw vs canonical）导致 `recordSuccess`/`recordFailure` 可能记录不同 key 的问题；抽取 `findProviderModel` 共用函数消除 `routes.ts` 与 `router.ts` 之间的重复 provider/model 查找逻辑。
+
 ## [2.3.16] - 2026-06-18
 
 ### Fixed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,9 @@
     "dev": "nodemon",
     "start": "node dist/cjs/server.cjs",
     "start:esm": "node dist/esm/server.mjs",
-    "lint": "eslint src --ext .ts,.tsx"
+    "lint": "eslint src --ext .ts,.tsx",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "llm",
@@ -50,10 +52,11 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@wengine-ai/claude-code-router-shared": "workspace:*",
     "@types/node": "^24.0.15",
+    "@wengine-ai/claude-code-router-shared": "workspace:*",
     "esbuild": "^0.25.1",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/core/src/__tests__/provider-health.test.ts
+++ b/packages/core/src/__tests__/provider-health.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ProviderHealthStore } from "../services/provider-health";
+
+describe("ProviderHealthStore", () => {
+  let store: ProviderHealthStore;
+
+  beforeEach(() => {
+    store = new ProviderHealthStore({ enabled: true });
+  });
+
+  // --- Empty provider/model guards (consolidated in getKey) ---
+
+  describe("empty provider/model guards", () => {
+    it("recordSuccess should be a no-op with empty provider", () => {
+      store.recordSuccess("", "model-a");
+      expect(store.getState("", "model-a")).toBeUndefined();
+    });
+
+    it("recordSuccess should be a no-op with empty model", () => {
+      store.recordSuccess("provider-a", "");
+      expect(store.getState("provider-a", "")).toBeUndefined();
+    });
+
+    it("recordFailure should be a no-op with empty provider", () => {
+      store.recordFailure("", "model-a", "err");
+      expect(store.getState("", "model-a")).toBeUndefined();
+    });
+
+    it("recordFailure should be a no-op with empty model", () => {
+      store.recordFailure("provider-a", "", "err");
+      expect(store.getState("provider-a", "")).toBeUndefined();
+    });
+
+    it("isAvailable should return false with empty provider", () => {
+      expect(store.isAvailable("", "model-a")).toBe(false);
+    });
+
+    it("isAvailable should return false with empty model", () => {
+      expect(store.isAvailable("provider-a", "")).toBe(false);
+    });
+
+    it("getState should return undefined with empty provider", () => {
+      expect(store.getState("", "model-a")).toBeUndefined();
+    });
+
+    it("getState should return undefined with empty model", () => {
+      expect(store.getState("provider-a", "")).toBeUndefined();
+    });
+
+    it("getPriority should return 2 (worst) with empty provider", () => {
+      expect(store.getPriority("", "model-a")).toBe(2);
+    });
+
+    it("getPriority should return 2 (worst) with empty model", () => {
+      expect(store.getPriority("provider-a", "")).toBe(2);
+    });
+
+    it("forceOpen should be a no-op with empty provider", () => {
+      store.forceOpen("", "model-a");
+      expect(store.getState("", "model-a")).toBeUndefined();
+    });
+
+    it("markRateLimited should be a no-op with empty provider", () => {
+      store.markRateLimited("", "model-a");
+      expect(store.getState("", "model-a")).toBeUndefined();
+    });
+
+    it("recover should be a no-op with empty provider", () => {
+      // Should not throw
+      store.recover("", "model-a");
+    });
+
+    it("restore should skip entries with empty provider", () => {
+      store.restore({
+        provider: "",
+        model: "model-a",
+        status: "open",
+        failureCount: 3,
+        successCount: 0,
+        lastFailureTime: Date.now(),
+        lastProbeTime: 0,
+      });
+      expect(store.getAllStates()).toHaveLength(0);
+    });
+
+    it("markProbeAttempt should be a no-op with empty provider", () => {
+      // Should not throw
+      store.markProbeAttempt("", "model-a");
+    });
+  });
+
+  // --- Normal operation (ensure guards don't break valid inputs) ---
+
+  describe("normal operation", () => {
+    it("recordFailure should track state for valid provider/model", () => {
+      store.recordFailure("provider-a", "model-a", "timeout");
+      const state = store.getState("provider-a", "model-a");
+      expect(state).toBeDefined();
+      expect(state!.failureCount).toBe(1);
+      expect(state!.status).toBe("closed");
+    });
+
+    it("recordFailure should transition to open after threshold", () => {
+      store.recordFailure("provider-a", "model-a", "err");
+      store.recordFailure("provider-a", "model-a", "err");
+      store.recordFailure("provider-a", "model-a", "err");
+      const state = store.getState("provider-a", "model-a");
+      expect(state!.status).toBe("open");
+    });
+
+    it("isAvailable should return true for healthy models", () => {
+      expect(store.isAvailable("provider-a", "model-a")).toBe(true);
+    });
+
+    it("isAvailable should return false for open (failed) models", () => {
+      store.recordFailure("provider-a", "model-a", "err");
+      store.recordFailure("provider-a", "model-a", "err");
+      store.recordFailure("provider-a", "model-a", "err");
+      expect(store.isAvailable("provider-a", "model-a")).toBe(false);
+    });
+
+    it("forceOpen should mark model as unavailable immediately", () => {
+      store.forceOpen("provider-a", "model-a", "manual");
+      expect(store.isAvailable("provider-a", "model-a")).toBe(false);
+    });
+
+    it("recordSuccess should recover half-open model", () => {
+      store.forceOpen("provider-a", "model-a");
+      // Manually set to half-open
+      const state = store.getState("provider-a", "model-a")!;
+      state.status = "half-open";
+      state.successCount = 0;
+
+      store.recordSuccess("provider-a", "model-a");
+      store.recordSuccess("provider-a", "model-a");
+      expect(store.getState("provider-a", "model-a")).toBeUndefined(); // deleted = fully recovered
+    });
+  });
+});

--- a/packages/core/src/__tests__/router-utils.test.ts
+++ b/packages/core/src/__tests__/router-utils.test.ts
@@ -107,4 +107,33 @@ describe("findProviderModel", () => {
     expect(result!.model).toBe("claude-sonnet-4-20250514");
     expect(result!.provider.name).toBe("Anthropic");
   });
+
+  // Regression guard for the fallback "Invalid URL" bug. handleFallback() in
+  // routes.ts feeds the matched provider straight into sendRequestToProvider,
+  // which calls `new URL(provider.baseUrl)`. The input array MUST therefore be
+  // registered LLMProvider objects (with `baseUrl`), NOT raw ConfigProvider
+  // objects from configService.get("providers") (which carry `api_base_url`
+  // instead and have no baseUrl, making new URL(undefined) throw "Invalid URL"
+  // for every fallback model). These two tests pin that contract so a future
+  // change of the data source is caught here rather than in production.
+  it("preserves baseUrl on the matched provider (LLMProvider contract for fallback URL construction)", () => {
+    const llmProviders = [
+      { name: "Zhipu", enabled: true, models: ["glm-5.2"], baseUrl: "https://open.bigmodel.cn/api/anthropic/v1/messages" },
+    ];
+    const result = findProviderModel(llmProviders, "zhipu", "GLM-5.2");
+    expect(result).not.toBeNull();
+    expect(result!.provider.baseUrl).toBe("https://open.bigmodel.cn/api/anthropic/v1/messages");
+  });
+
+  it("does not synthesize a baseUrl when the input array lacks it (raw ConfigProvider shape)", () => {
+    // ConfigProvider uses `api_base_url`, not `baseUrl` — this is exactly the
+    // shape configService.get("providers") returns. If fallback ever feeds
+    // this shape to sendRequestToProvider, provider.baseUrl is undefined.
+    const configProviders = [
+      { name: "Zhipu", enabled: true, models: ["glm-5.2"], api_base_url: "https://open.bigmodel.cn/api/anthropic/v1/messages" },
+    ];
+    const result = findProviderModel(configProviders, "zhipu", "glm-5.2");
+    expect(result).not.toBeNull();
+    expect((result!.provider as any).baseUrl).toBeUndefined();
+  });
 });

--- a/packages/core/src/__tests__/router-utils.test.ts
+++ b/packages/core/src/__tests__/router-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock external dependencies before importing the module under test
+vi.mock("../services/provider-health", () => {
+  let _available = true;
+  return {
+    getHealthStore: () => ({
+      isAvailable: () => _available,
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+    }),
+    __setAvailable: (v: boolean) => { _available = v; },
+  };
+});
+
+vi.mock("../utils/fallback-promotion", () => ({
+  getFallbackPromotionStore: () => ({
+    getPromotion: () => null,
+    clear: vi.fn(),
+  }),
+}));
+
+vi.mock("../services/quota", () => ({
+  getQuotaResult: () => null,
+}));
+
+import { findProviderModel } from "../utils/router";
+
+// --- findProviderModel ---
+
+describe("findProviderModel", () => {
+  const providers = [
+    {
+      name: "OpenAI",
+      enabled: true,
+      models: ["gpt-4o", "gpt-4o-mini", "o3"],
+    },
+    {
+      name: "Anthropic",
+      enabled: true,
+      models: ["claude-sonnet-4-20250514", "claude-opus-4-20250514"],
+    },
+    {
+      name: "Disabled",
+      enabled: false,
+      models: ["disabled-model"],
+    },
+  ];
+
+  it("should find an existing model with exact name match", () => {
+    const result = findProviderModel(providers, "OpenAI", "gpt-4o");
+    expect(result).not.toBeNull();
+    expect(result!.provider.name).toBe("OpenAI");
+    expect(result!.model).toBe("gpt-4o");
+  });
+
+  it("should find a model with case-insensitive provider name", () => {
+    const result = findProviderModel(providers, "openai", "gpt-4o");
+    expect(result).not.toBeNull();
+    expect(result!.provider.name).toBe("OpenAI");
+    expect(result!.model).toBe("gpt-4o");
+  });
+
+  it("should find a model with case-insensitive model name", () => {
+    const result = findProviderModel(providers, "OpenAI", "GPT-4O");
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe("gpt-4o");
+  });
+
+  it("should return null for non-existent provider", () => {
+    const result = findProviderModel(providers, "Google", "gemini-pro");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for non-existent model in existing provider", () => {
+    const result = findProviderModel(providers, "OpenAI", "gpt-3.5-turbo");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for disabled provider", () => {
+    const result = findProviderModel(providers, "Disabled", "disabled-model");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for empty provider name", () => {
+    const result = findProviderModel(providers, "", "gpt-4o");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for empty model name", () => {
+    const result = findProviderModel(providers, "OpenAI", "");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for provider with no models array", () => {
+    const result = findProviderModel(
+      [{ name: "Empty", enabled: true }],
+      "Empty",
+      "any-model"
+    );
+    expect(result).toBeNull();
+  });
+
+  it("should return canonical (case-matched) model name from provider config", () => {
+    const result = findProviderModel(providers, "anthropic", "CLAUDE-SONNET-4-20250514");
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe("claude-sonnet-4-20250514");
+    expect(result!.provider.name).toBe("Anthropic");
+  });
+});

--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -625,7 +625,14 @@ async function handleFallback(
 
       // Resolve the fallback model against the live provider registry early so
       // both the success and error paths use the same canonical values.
-      const providers = fastify.configService.get<any[]>("providers") || [];
+      // IMPORTANT: use providerService.getProviders() (registered LLMProvider[]
+      // with the `baseUrl` field) rather than configService.get("providers")
+      // (raw ConfigProvider[] with `api_base_url`). sendRequestToProvider below
+      // reads provider.baseUrl to build the upstream URL — a ConfigProvider has
+      // no baseUrl, so new URL(undefined) throws "Invalid URL" for every
+      // fallback model. router.ts can use the raw array because it only reads
+      // name/models/enabled, never baseUrl.
+      const providers = fastify.providerService.getProviders();
       const configuredFallback = findProviderModel(
         providers,
         fallbackRoute.provider,

--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -30,6 +30,26 @@ import { router } from "@/utils/router";
 // name to /v1/responses.
 const CCR_FAMILY_ALIAS = /^ccr-(opus|sonnet|haiku)(\[1m\])?$/i;
 
+function findConfiguredProviderModel(
+  providerService: ProviderService,
+  providerName: string,
+  modelName: string
+): { provider: LLMProvider; model: string } | null {
+  const provider = providerService.getProvider(providerName);
+  if (!provider || provider.enabled === false) {
+    return null;
+  }
+
+  const model = provider.models?.find(
+    (item: any) => String(item).toLowerCase() === modelName.toLowerCase()
+  );
+  if (!model) {
+    return null;
+  }
+
+  return { provider, model };
+}
+
 /**
  * Normalize a Responses API (Codex) request body into a unified chat request so
  * downstream transformers (and the family router) can process it.
@@ -627,35 +647,36 @@ async function handleFallback(
       const model = fallbackRoute.model;
 
       try {
+        const configuredFallback = findConfiguredProviderModel(
+          fastify.providerService,
+          fallbackProvider,
+          model
+        );
+        if (!configuredFallback) {
+          req.log.warn(`Fallback model ${fallbackModel} is not configured or provider is disabled, skipping`);
+          continue;
+        }
+
         // Skip if model is in fail pool (open state)
-        if (!healthStore.isAvailable(fallbackProvider, model)) {
+        if (!healthStore.isAvailable(configuredFallback.provider.name, configuredFallback.model)) {
           req.log.warn(`Fallback model ${fallbackModel} unavailable (fail pool), skipping`);
           continue;
         }
 
-        req.log.info(`Trying fallback model: ${fallbackModel}`);
+        req.log.info(`Trying fallback model: ${configuredFallback.provider.name},${configuredFallback.model}`);
 
         // Update request with fallback model
         const newBody = { ...(req.body as any) };
-        newBody.model = model;
+        newBody.model = configuredFallback.model;
 
         // Create new request object with updated provider and body
         const newReq = {
           ...req,
-          provider: fallbackProvider,
+          provider: configuredFallback.provider.name,
           body: newBody,
         };
 
-        const provider = fastify.providerService.getProvider(fallbackProvider);
-        if (!provider) {
-          req.log.warn(`Fallback provider '${fallbackProvider}' not found, skipping`);
-          continue;
-        }
-
-        if (provider.enabled === false) {
-          req.log.warn(`Fallback provider '${fallbackProvider}' is disabled, skipping`);
-          continue;
-        }
+        const provider = configuredFallback.provider;
 
         // Process request transformer chain
         const { requestBody, config, bypass } = await processRequestTransformers(
@@ -680,7 +701,7 @@ async function handleFallback(
         // Capture rate limit headers from upstream response
         try {
           if (provider?.baseUrl && response?.headers) {
-            captureRateLimitHeaders(fallbackProvider, provider.baseUrl, response.headers);
+            captureRateLimitHeaders(configuredFallback.provider.name, provider.baseUrl, response.headers);
           }
         } catch {}
 
@@ -698,10 +719,10 @@ async function handleFallback(
           }
         );
 
-        req.log.info(`Fallback model ${fallbackModel} succeeded`);
+        req.log.info(`Fallback model ${configuredFallback.provider.name},${configuredFallback.model} succeeded`);
 
         // Record success for the fallback model
-        healthStore.recordSuccess(fallbackProvider, model);
+        healthStore.recordSuccess(configuredFallback.provider.name, configuredFallback.model);
 
         // Promote the fallback model globally for this primary + scenario
         // This ensures all clients skip the failing primary until TTL expires
@@ -711,10 +732,10 @@ async function handleFallback(
             originalProvider,
             originalModel,
             scenarioType,
-            fallbackProvider,
-            model
+            configuredFallback.provider.name,
+            configuredFallback.model
           );
-          req.log.info(`Promoted fallback model ${fallbackProvider},${model} for ${originalProvider},${originalModel}:${scenarioType}`);
+          req.log.info(`Promoted fallback model ${configuredFallback.provider.name},${configuredFallback.model} for ${originalProvider},${originalModel}:${scenarioType}`);
 
           // Immediately mark the original model as unavailable so routing skips it
           // even when promotion TTL expires or is cleared.
@@ -729,7 +750,7 @@ async function handleFallback(
         }
 
         // Write back to original req so onResponse hook records correct provider/model
-        req.provider = fallbackProvider;
+        req.provider = configuredFallback.provider.name;
         req.body = newBody;
 
         // Format and return response

--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -23,32 +23,12 @@ import { getHealthStore } from "@/services/provider-health";
 import { captureRateLimitHeaders } from "@/services/rate-limit";
 import { getFallbackPromotionStore } from "@/utils/fallback-promotion";
 import { OpenAIResponsesTransformer } from "../transformer/openai.responses.transformer";
-import { router } from "@/utils/router";
+import { router, findProviderModel } from "@/utils/router";
 
 // Matches the CCR model-family aliases that CCR injects into managed clients
 // (e.g. "ccr-opus", "ccr-sonnet[1m]"). Codex sends one of these as a bare model
 // name to /v1/responses.
 const CCR_FAMILY_ALIAS = /^ccr-(opus|sonnet|haiku)(\[1m\])?$/i;
-
-function findConfiguredProviderModel(
-  providerService: ProviderService,
-  providerName: string,
-  modelName: string
-): { provider: LLMProvider; model: string } | null {
-  const provider = providerService.getProvider(providerName);
-  if (!provider || provider.enabled === false) {
-    return null;
-  }
-
-  const model = provider.models?.find(
-    (item: any) => String(item).toLowerCase() === modelName.toLowerCase()
-  );
-  if (!model) {
-    return null;
-  }
-
-  return { provider, model };
-}
 
 /**
  * Normalize a Responses API (Codex) request body into a unified chat request so
@@ -643,36 +623,40 @@ async function handleFallback(
       }
       attemptedFallbacks.add(fallbackRoute.key);
 
-      const fallbackProvider = fallbackRoute.provider;
-      const model = fallbackRoute.model;
+      // Resolve the fallback model against the live provider registry early so
+      // both the success and error paths use the same canonical values.
+      const providers = fastify.configService.get<any[]>("providers") || [];
+      const configuredFallback = findProviderModel(
+        providers,
+        fallbackRoute.provider,
+        fallbackRoute.model
+      );
+      if (!configuredFallback) {
+        req.log.warn(`Fallback model ${fallbackModel} is not configured or provider is disabled, skipping`);
+        continue;
+      }
+
+      // Shorthand aliases used throughout the try/catch
+      const fbProviderName = configuredFallback.provider.name;
+      const fbModel = configuredFallback.model;
 
       try {
-        const configuredFallback = findConfiguredProviderModel(
-          fastify.providerService,
-          fallbackProvider,
-          model
-        );
-        if (!configuredFallback) {
-          req.log.warn(`Fallback model ${fallbackModel} is not configured or provider is disabled, skipping`);
-          continue;
-        }
-
         // Skip if model is in fail pool (open state)
-        if (!healthStore.isAvailable(configuredFallback.provider.name, configuredFallback.model)) {
+        if (!healthStore.isAvailable(fbProviderName, fbModel)) {
           req.log.warn(`Fallback model ${fallbackModel} unavailable (fail pool), skipping`);
           continue;
         }
 
-        req.log.info(`Trying fallback model: ${configuredFallback.provider.name},${configuredFallback.model}`);
+        req.log.info(`Trying fallback model: ${fbProviderName},${fbModel}`);
 
         // Update request with fallback model
         const newBody = { ...(req.body as any) };
-        newBody.model = configuredFallback.model;
+        newBody.model = fbModel;
 
         // Create new request object with updated provider and body
         const newReq = {
           ...req,
-          provider: configuredFallback.provider.name,
+          provider: fbProviderName,
           body: newBody,
         };
 
@@ -701,7 +685,7 @@ async function handleFallback(
         // Capture rate limit headers from upstream response
         try {
           if (provider?.baseUrl && response?.headers) {
-            captureRateLimitHeaders(configuredFallback.provider.name, provider.baseUrl, response.headers);
+            captureRateLimitHeaders(fbProviderName, provider.baseUrl, response.headers);
           }
         } catch {}
 
@@ -719,10 +703,10 @@ async function handleFallback(
           }
         );
 
-        req.log.info(`Fallback model ${configuredFallback.provider.name},${configuredFallback.model} succeeded`);
+        req.log.info(`Fallback model ${fbProviderName},${fbModel} succeeded`);
 
         // Record success for the fallback model
-        healthStore.recordSuccess(configuredFallback.provider.name, configuredFallback.model);
+        healthStore.recordSuccess(fbProviderName, fbModel);
 
         // Promote the fallback model globally for this primary + scenario
         // This ensures all clients skip the failing primary until TTL expires
@@ -732,10 +716,10 @@ async function handleFallback(
             originalProvider,
             originalModel,
             scenarioType,
-            configuredFallback.provider.name,
-            configuredFallback.model
+            fbProviderName,
+            fbModel
           );
-          req.log.info(`Promoted fallback model ${configuredFallback.provider.name},${configuredFallback.model} for ${originalProvider},${originalModel}:${scenarioType}`);
+          req.log.info(`Promoted fallback model ${fbProviderName},${fbModel} for ${originalProvider},${originalModel}:${scenarioType}`);
 
           // Immediately mark the original model as unavailable so routing skips it
           // even when promotion TTL expires or is cleared.
@@ -750,19 +734,19 @@ async function handleFallback(
         }
 
         // Write back to original req so onResponse hook records correct provider/model
-        req.provider = configuredFallback.provider.name;
+        req.provider = fbProviderName;
         req.body = newBody;
 
         // Format and return response
         return formatResponse(finalResponse, reply, newBody, fastify);
       } catch (fallbackError: any) {
-        healthStore.recordFailure(fallbackProvider, model, fallbackError.message);
-        req.log.warn(`Fallback model ${fallbackRoute.key} failed: ${fallbackError.message}`);
+        healthStore.recordFailure(fbProviderName, fbModel, fallbackError.message);
+        req.log.warn(`Fallback model ${fbProviderName},${fbModel} failed: ${fallbackError.message}`);
 
         // Record failed fallback attempt in usage stats
         fastify.recordUsage?.({
-          provider: fallbackProvider,
-          model,
+          provider: fbProviderName,
+          model: fbModel,
           originalModel: (req.body as any).model,
           scenarioType,
           modelFamily: (req as any).modelFamily,

--- a/packages/core/src/services/provider-health.ts
+++ b/packages/core/src/services/provider-health.ts
@@ -59,7 +59,14 @@ export class ProviderHealthStore {
     this.config = { ...DEFAULT_CONFIG, ...config };
   }
 
-  private getKey(provider: string, model: string): string {
+  /**
+   * Build the composite key used to index provider/model state.
+   * Returns null when either part is empty, which signals the caller to
+   * short-circuit (skip the operation) instead of creating a bogus entry like
+   * ",model" or "provider," that would pollute the health pool.
+   */
+  private getKey(provider: string, model: string): string | null {
+    if (!provider || !model) return null;
     return `${provider},${model}`;
   }
 
@@ -69,9 +76,9 @@ export class ProviderHealthStore {
    */
   recordSuccess(provider: string, model: string): void {
     if (!this.config.enabled) return;
-    if (!provider || !model) return;
 
     const key = this.getKey(provider, model);
+    if (!key) return;
     let state = this.states.get(key);
 
     if (!state) {
@@ -123,9 +130,9 @@ export class ProviderHealthStore {
    */
   recordFailure(provider: string, model: string, error?: string): void {
     if (!this.config.enabled) return;
-    if (!provider || !model) return;
 
     const key = this.getKey(provider, model);
+    if (!key) return;
     let state = this.states.get(key);
 
     if (!state) {
@@ -162,8 +169,9 @@ export class ProviderHealthStore {
    * Get current health state for a provider/model
    */
   getState(provider: string, model: string): ProviderHealthState | undefined {
-    if (!provider || !model) return undefined;
-    return this.states.get(this.getKey(provider, model));
+    const key = this.getKey(provider, model);
+    if (!key) return undefined;
+    return this.states.get(key);
   }
 
   /**
@@ -172,7 +180,9 @@ export class ProviderHealthStore {
    */
   isAvailable(provider: string, model: string): boolean {
     if (!this.config.enabled) return true;
-    if (!provider || !model) return false;
+
+    const key = this.getKey(provider, model);
+    if (!key) return false;
 
     const state = this.getState(provider, model);
     if (!state) return true; // No state = closed (healthy)
@@ -200,7 +210,9 @@ export class ProviderHealthStore {
    */
   getPriority(provider: string, model: string): number {
     if (!this.config.enabled) return 0;
-    if (!provider || !model) return 2;
+
+    const key = this.getKey(provider, model);
+    if (!key) return 2;
 
     const state = this.getState(provider, model);
     if (!state) return 0;
@@ -254,9 +266,9 @@ export class ProviderHealthStore {
    */
   forceOpen(provider: string, model: string, error?: string): void {
     if (!this.config.enabled) return;
-    if (!provider || !model) return;
 
     const key = this.getKey(provider, model);
+    if (!key) return;
     let state = this.states.get(key);
 
     if (!state) {
@@ -291,9 +303,9 @@ export class ProviderHealthStore {
    */
   markRateLimited(provider: string, model: string, retryAfterSeconds?: number, error?: string): void {
     if (!this.config.enabled) return;
-    if (!provider || !model) return;
 
     const key = this.getKey(provider, model);
+    if (!key) return;
     let state = this.states.get(key);
 
     if (!state) {
@@ -348,6 +360,7 @@ export class ProviderHealthStore {
    */
   markProbeAttempt(provider: string, model: string): void {
     const key = this.getKey(provider, model);
+    if (!key) return;
     const state = this.states.get(key);
     if (state && state.status === 'open') {
       state.lastProbeTime = Date.now();
@@ -365,8 +378,8 @@ export class ProviderHealthStore {
    * Recover a provider/model from health fail pool
    */
   recover(provider: string, model: string): void {
-    if (!provider || !model) return;
     const key = this.getKey(provider, model);
+    if (!key) return;
     this.states.delete(key);
   }
 
@@ -381,7 +394,9 @@ export class ProviderHealthStore {
    * Restore a previously persisted health state.
    */
   restore(state: ProviderHealthState): void {
-    this.states.set(this.getKey(state.provider, state.model), { ...state });
+    const key = this.getKey(state.provider, state.model);
+    if (!key) return;
+    this.states.set(key, { ...state });
   }
 
   /**

--- a/packages/core/src/services/provider-health.ts
+++ b/packages/core/src/services/provider-health.ts
@@ -69,6 +69,7 @@ export class ProviderHealthStore {
    */
   recordSuccess(provider: string, model: string): void {
     if (!this.config.enabled) return;
+    if (!provider || !model) return;
 
     const key = this.getKey(provider, model);
     let state = this.states.get(key);
@@ -122,6 +123,7 @@ export class ProviderHealthStore {
    */
   recordFailure(provider: string, model: string, error?: string): void {
     if (!this.config.enabled) return;
+    if (!provider || !model) return;
 
     const key = this.getKey(provider, model);
     let state = this.states.get(key);
@@ -160,6 +162,7 @@ export class ProviderHealthStore {
    * Get current health state for a provider/model
    */
   getState(provider: string, model: string): ProviderHealthState | undefined {
+    if (!provider || !model) return undefined;
     return this.states.get(this.getKey(provider, model));
   }
 
@@ -169,6 +172,7 @@ export class ProviderHealthStore {
    */
   isAvailable(provider: string, model: string): boolean {
     if (!this.config.enabled) return true;
+    if (!provider || !model) return false;
 
     const state = this.getState(provider, model);
     if (!state) return true; // No state = closed (healthy)
@@ -196,6 +200,7 @@ export class ProviderHealthStore {
    */
   getPriority(provider: string, model: string): number {
     if (!this.config.enabled) return 0;
+    if (!provider || !model) return 2;
 
     const state = this.getState(provider, model);
     if (!state) return 0;
@@ -249,6 +254,7 @@ export class ProviderHealthStore {
    */
   forceOpen(provider: string, model: string, error?: string): void {
     if (!this.config.enabled) return;
+    if (!provider || !model) return;
 
     const key = this.getKey(provider, model);
     let state = this.states.get(key);
@@ -285,6 +291,7 @@ export class ProviderHealthStore {
    */
   markRateLimited(provider: string, model: string, retryAfterSeconds?: number, error?: string): void {
     if (!this.config.enabled) return;
+    if (!provider || !model) return;
 
     const key = this.getKey(provider, model);
     let state = this.states.get(key);
@@ -358,6 +365,7 @@ export class ProviderHealthStore {
    * Recover a provider/model from health fail pool
    */
   recover(provider: string, model: string): void {
+    if (!provider || !model) return;
     const key = this.getKey(provider, model);
     this.states.delete(key);
   }

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -564,6 +564,7 @@ export class AnthropicTransformer implements Transformer {
                   const promptTokens = chunk.usage?.prompt_tokens || 0;
                   // Keep Anthropic protocol semantics for Claude Code: input_tokens is net of cache reads.
                   const inputTokens = promptTokens - cachedTokens;
+                  const completionTokens = chunk.usage?.completion_tokens || 0;
                   this.logger?.info({
                     debug_log: true,
                     reqId: context.req.id,
@@ -571,12 +572,25 @@ export class AnthropicTransformer implements Transformer {
                     providerUsage: chunk.usage,
                     mappedUsage: {
                       input_tokens: inputTokens,
-                      output_tokens: chunk.usage?.completion_tokens || 0,
+                      output_tokens: completionTokens,
                       cache_read_input_tokens: cachedTokens,
                     },
                     choicesLength: Array.isArray(chunk.choices) ? chunk.choices.length : undefined,
                     finishReason: choice?.finish_reason,
                   });
+                  // Some OpenAI-compatible upstreams (e.g. fireworks-hosted GLM-5.2)
+                  // report real usage on the first chunk but emit an all-zero usage
+                  // object on the final/stop chunk. Overwriting the already-captured
+                  // real usage with those zeros produced message_delta.usage of all
+                  // zeros, which zeroed out the usage stats for the whole request.
+                  // Merge field-by-field, only replacing a field when the incoming
+                  // value is non-zero, so the real first-chunk usage survives a
+                  // trailing all-zero usage frame.
+                  const incomingUsage = {
+                    input_tokens: inputTokens,
+                    output_tokens: completionTokens,
+                    cache_read_input_tokens: cachedTokens,
+                  };
                   if (!stopReasonMessageDelta) {
                     stopReasonMessageDelta = {
                       type: "message_delta",
@@ -584,17 +598,15 @@ export class AnthropicTransformer implements Transformer {
                         stop_reason: "end_turn",
                         stop_sequence: null,
                       },
-                      usage: {
-                        input_tokens: inputTokens,
-                        output_tokens: chunk.usage?.completion_tokens || 0,
-                        cache_read_input_tokens: cachedTokens,
-                      },
+                      usage: { ...incomingUsage },
                     };
                   } else {
+                    const prev = stopReasonMessageDelta.usage || {};
                     stopReasonMessageDelta.usage = {
-                      input_tokens: inputTokens,
-                      output_tokens: chunk.usage?.completion_tokens || 0,
-                      cache_read_input_tokens: cachedTokens,
+                      input_tokens: incomingUsage.input_tokens || prev.input_tokens || 0,
+                      output_tokens: incomingUsage.output_tokens || prev.output_tokens || 0,
+                      cache_read_input_tokens:
+                        incomingUsage.cache_read_input_tokens || prev.cache_read_input_tokens || 0,
                     };
                   }
                 }

--- a/packages/core/src/utils/router.ts
+++ b/packages/core/src/utils/router.ts
@@ -216,6 +216,33 @@ function parseConfiguredRoute(modelName: string): { providerName: string; routeM
   return { providerName, routeModel };
 }
 
+/**
+ * Look up a provider and model by name in the current provider list.
+ * Returns canonical (case-matched) values or null when the provider is
+ * missing, disabled, or the model is not listed under it.
+ */
+export function findProviderModel(
+  providers: any[],
+  providerName: string,
+  modelName: string
+): { provider: any; model: string } | null {
+  const provider = providers.find(
+    (p: any) => p.name.toLowerCase() === providerName.toLowerCase()
+  );
+  if (!provider || provider.enabled === false) {
+    return null;
+  }
+
+  const model = provider.models?.find(
+    (m: any) => String(m).toLowerCase() === modelName.toLowerCase()
+  );
+  if (!model) {
+    return null;
+  }
+
+  return { provider, model: String(model) };
+}
+
 function resolveConfiguredModel(
   modelName: string,
   providers: any[],
@@ -230,12 +257,27 @@ function resolveConfiguredModel(
 
   const { providerName, routeModel } = route;
 
-  const finalProvider = providers.find(
-    (p: any) => p.name.toLowerCase() === providerName.toLowerCase()
-  );
+  const found = findProviderModel(providers, providerName, routeModel);
 
-  // Switch has the highest priority. If disabled, return null immediately.
-  if (finalProvider && finalProvider.enabled === false) {
+  // Provider disabled or missing — skip immediately
+  if (!found) {
+    // Still need to check fallback promotion even when the primary is stale,
+    // because a previously promoted fallback may still be valid.
+    if (enableFallback === true && scenarioType && !skipHealthCheck) {
+      const fallbackPromotion = getFallbackPromotionStore();
+      const promoted = fallbackPromotion.getPromotion(providerName, routeModel, scenarioType, providers);
+      if (promoted) {
+        const promotedRoute = parseConfiguredRoute(promoted);
+        if (promotedRoute) {
+          const promotedFound = findProviderModel(providers, promotedRoute.providerName, promotedRoute.routeModel);
+          if (promotedFound) {
+            return `${promotedFound.provider.name},${promotedFound.model}`;
+          }
+        }
+        // Promoted model no longer valid, clear it and proceed normally
+        fallbackPromotion.clear(providerName, routeModel, scenarioType);
+      }
+    }
     return null;
   }
 
@@ -245,17 +287,11 @@ function resolveConfiguredModel(
     const fallbackPromotion = getFallbackPromotionStore();
     const promoted = fallbackPromotion.getPromotion(providerName, routeModel, scenarioType, providers);
     if (promoted) {
-      // Parse the promoted model to verify it exists in providers
       const promotedRoute = parseConfiguredRoute(promoted);
       if (promotedRoute) {
-        const promotedProvider = providers.find(
-          (p: any) => p.name.toLowerCase() === promotedRoute.providerName.toLowerCase()
-        );
-        const promotedModel = promotedProvider?.models?.find(
-          (m: any) => String(m).toLowerCase() === promotedRoute.routeModel.toLowerCase()
-        );
-        if (promotedProvider && promotedModel) {
-          return `${promotedProvider.name},${promotedModel}`;
+        const promotedFound = findProviderModel(providers, promotedRoute.providerName, promotedRoute.routeModel);
+        if (promotedFound) {
+          return `${promotedFound.provider.name},${promotedFound.model}`;
         }
       }
       // Promoted model no longer valid, clear it and proceed normally
@@ -266,13 +302,13 @@ function resolveConfiguredModel(
   // Check health status - skip if model is in fail pool
   if (!skipHealthCheck) {
     const healthStore = getHealthStore();
-    if (!healthStore.isAvailable(providerName, routeModel)) {
+    if (!healthStore.isAvailable(found.provider.name, found.model)) {
       return null; // Model is unavailable, return null to signal skip
     }
   }
 
   // Check quota status - skip if provider quota is exhausted
-  const quotaResult = getQuotaResult(providerName);
+  const quotaResult = getQuotaResult(found.provider.name);
   if (quotaResult) {
     const is5hExhausted = quotaResult.limitDaily !== undefined &&
       quotaResult.usedDailyBalance !== undefined &&
@@ -286,19 +322,7 @@ function resolveConfiguredModel(
     }
   }
 
-  const finalModel = finalProvider?.models?.find(
-    (m: any) => String(m).toLowerCase() === routeModel.toLowerCase()
-  );
-
-  if (finalProvider && finalModel) {
-    return `${finalProvider.name},${finalModel}`;
-  }
-
-  // A configured provider,model route must resolve against the current provider
-  // registry. During config hot reloads the referenced model may have been
-  // removed; treating that stale string as valid lets deleted models enter the
-  // request/fallback path and poison the health pool.
-  return null;
+  return `${found.provider.name},${found.model}`;
 }
 
 function resolveScenarioFallbackModel(

--- a/packages/core/src/utils/router.ts
+++ b/packages/core/src/utils/router.ts
@@ -294,7 +294,11 @@ function resolveConfiguredModel(
     return `${finalProvider.name},${finalModel}`;
   }
 
-  return modelName;
+  // A configured provider,model route must resolve against the current provider
+  // registry. During config hot reloads the referenced model may have been
+  // removed; treating that stale string as valid lets deleted models enter the
+  // request/fallback path and poison the health pool.
+  return null;
 }
 
 function resolveScenarioFallbackModel(
@@ -825,7 +829,12 @@ export const router = async (req: any, _res: any, context: RouterContext) => {
       }
     }
 
-    req.body.model = model;
+    if (typeof model === "string" && model.trim()) {
+      req.body.model = model;
+    } else {
+      req.log.warn(`Router could not resolve a valid model for ${req.originalModel || req.body.model}; keeping original request model`);
+      req.scenarioType = req.scenarioType || 'default';
+    }
   } catch (error: any) {
     req.log.error(`Error in router middleware: ${error.message}`);
     req.body.model = routerConfig?.default;

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,9 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "node ../../scripts/build-server.js",
-    "dev": "ts-node src/index.ts"
+    "dev": "ts-node src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "claude",
@@ -38,6 +40,7 @@
     "esbuild": "^0.25.1",
     "fastify": "^5.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/server/src/__tests__/usage-merge.test.ts
+++ b/packages/server/src/__tests__/usage-merge.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeUsagePayload,
+  mergeUsageCapture,
+} from "../utils/usage-merge";
+
+describe("normalizeUsagePayload", () => {
+  it("maps Anthropic-style usage fields verbatim", () => {
+    const u = normalizeUsagePayload({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 30,
+      cache_creation_input_tokens: 10,
+    });
+    expect(u.input_tokens).toBe(100);
+    expect(u.output_tokens).toBe(50);
+    expect(u.cache_read_input_tokens).toBe(30);
+    expect(u.cache_creation_input_tokens).toBe(10);
+  });
+
+  it("maps OpenAI Chat Completions usage (prompt_tokens/completion_tokens)", () => {
+    const u = normalizeUsagePayload({ prompt_tokens: 100, completion_tokens: 50 });
+    expect(u.input_tokens).toBe(100);
+    expect(u.output_tokens).toBe(50);
+  });
+
+  it("reads cached_tokens from OpenAI prompt_tokens_details", () => {
+    const u = normalizeUsagePayload({
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      prompt_tokens_details: { cached_tokens: 80 },
+    });
+    expect(u.cache_read_input_tokens).toBe(80);
+  });
+
+  it("returns undefined for non-object usage", () => {
+    expect(normalizeUsagePayload(null)).toBeUndefined();
+    expect(normalizeUsagePayload(undefined)).toBeUndefined();
+    expect(normalizeUsagePayload("nope")).toBeUndefined();
+  });
+});
+
+describe("mergeUsageCapture", () => {
+  it("preserves real usage captured on message_start against a trailing all-zero frame", () => {
+    // Simulates the fireworks/GLM-5.2 bug: message_start reports real input,
+    // message_delta emits all-zero usage on the stop chunk.
+    const start = normalizeUsagePayload({ input_tokens: 60005, output_tokens: 0 });
+    const afterStart = mergeUsageCapture({}, start, true); // message_start: reset base
+    expect(afterStart.input_tokens).toBe(60005);
+
+    const trailingZero = normalizeUsagePayload({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+    });
+    const afterDelta = mergeUsageCapture(afterStart, trailingZero, false); // message_delta
+    // The all-zero frame must NOT wipe out the real input captured at start.
+    expect(afterDelta.input_tokens).toBe(60005);
+    expect(afterDelta.output_tokens).toBe(0);
+  });
+
+  it("updates a field only when the incoming frame carries a non-zero value", () => {
+    const base = { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 5, cache_creation_input_tokens: 0 };
+    // A later frame reports the final output_tokens (cumulative) and a cache read.
+    const merged = mergeUsageCapture(base, { input_tokens: 0, output_tokens: 87, cache_read_input_tokens: 12, cache_creation_input_tokens: 0 }, false);
+    expect(merged.input_tokens).toBe(100); // unchanged (incoming 0)
+    expect(merged.output_tokens).toBe(87); // updated (incoming non-zero)
+    expect(merged.cache_read_input_tokens).toBe(12); // updated
+  });
+
+  it("resetBase=true discards stale fields from a previous request in the same session", () => {
+    const stale = { input_tokens: 9999, output_tokens: 9999, cache_read_input_tokens: 9999, cache_creation_input_tokens: 9999 };
+    const fresh = mergeUsageCapture(stale, { input_tokens: 10, output_tokens: 5 }, true);
+    expect(fresh.input_tokens).toBe(10);
+    expect(fresh.output_tokens).toBe(5);
+    expect(fresh.cache_read_input_tokens).toBe(0); // stale value NOT carried over
+    expect(fresh.cache_creation_input_tokens).toBe(0);
+  });
+
+  it("treats an all-zero first frame as zeros (no prior value to fall back to)", () => {
+    const merged = mergeUsageCapture({}, { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, true);
+    expect(merged.input_tokens).toBe(0);
+    expect(merged.output_tokens).toBe(0);
+  });
+
+  it("handles missing/undefined inputs without throwing", () => {
+    expect(mergeUsageCapture(undefined, undefined, true)).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    });
+  });
+
+  it("regression: the exact fireworks/GLM-5.2 sequence that produced 0/0 records", () => {
+    // 1) message_start: real input reported, output 0
+    const startUsage = normalizeUsagePayload({ input_tokens: 60005, output_tokens: 0 });
+    let cache = mergeUsageCapture({}, startUsage, true);
+    // 2) content deltas (no usage)
+    // 3) message_delta: all-zero usage frame (the bug)
+    const trailingZero = normalizeUsagePayload({ input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0 });
+    cache = mergeUsageCapture(cache, trailingZero, false);
+    // Before the fix this collapsed to all zeros; input must survive.
+    expect(cache.input_tokens).toBe(60005);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,6 +28,10 @@ import { EventEmitter } from "node:events";
 import { performance } from "node:perf_hooks";
 import { pluginManager, tokenSpeedPlugin } from "@wengine-ai/llms";
 import { append as appendUsage, readTokenSpeedStats } from "./services/usage-store";
+import {
+  normalizeUsagePayload,
+  mergeUsageCapture,
+} from "./utils/usage-merge";
 
 const event = new EventEmitter()
 
@@ -86,38 +90,6 @@ function detectClientType(req: any): string {
   // Direct /v1/messages call without ccr- prefix → generic API
   if (pathname.endsWith("/v1/messages")) return "api";
   return "unknown";
-}
-
-function getUsageCacheReadInputTokens(usage: any): number {
-  return (
-    usage?.cache_read_input_tokens ??
-    usage?.input_tokens_details?.cached_tokens ??
-    usage?.prompt_tokens_details?.cached_tokens ??
-    0
-  );
-}
-
-function getUsageCacheCreationInputTokens(usage: any): number {
-  return (
-    usage?.cache_creation_input_tokens ??
-    usage?.input_tokens_details?.cache_creation_tokens ??
-    usage?.input_tokens_details?.cache_write_tokens ??
-    usage?.prompt_tokens_details?.cache_creation_tokens ??
-    usage?.prompt_tokens_details?.cache_write_tokens ??
-    0
-  );
-}
-
-function normalizeUsagePayload(usage: any): any {
-  if (!usage || typeof usage !== "object") return undefined;
-
-  return {
-    ...usage,
-    input_tokens: usage.input_tokens ?? usage.prompt_tokens ?? 0,
-    output_tokens: usage.output_tokens ?? usage.completion_tokens ?? 0,
-    cache_read_input_tokens: getUsageCacheReadInputTokens(usage),
-    cache_creation_input_tokens: getUsageCacheCreationInputTokens(usage),
-  };
 }
 
 function isRateLimitMessage(statusCode: number, message?: string): boolean {
@@ -799,9 +771,10 @@ async function getServer(options: RunOptions = {}) {
                 const existingUsage = sessionUsageCache.get(usageSessionId) || {};
                 const normalizedUsage = normalizeUsagePayload(data.usage);
                 // Reset cache on message_start to avoid stale fields from previous requests
-                // (e.g. cache_creation_input_tokens carried over from a different model)
-                const base = event === 'message_start' ? {} : existingUsage;
-                const mergedUsage = { ...base, ...normalizedUsage };
+                // (e.g. cache_creation_input_tokens carried over from a different model).
+                // mergeUsageCapture refuses to let an all-zero frame overwrite a
+                // real value captured earlier (see its doc comment).
+                const mergedUsage = mergeUsageCapture(existingUsage, normalizedUsage, event === 'message_start');
                 req.log?.info?.({
                   debug_log: true,
                   reqId: req.id,
@@ -831,15 +804,8 @@ async function getServer(options: RunOptions = {}) {
                 // Reset base on a fresh response.completed to prevent stale fields
                 // from a previous request leaking into the new one (same as the
                 // message_start sentinel used in the Anthropic path above).
-                const existingUsage = event === 'response.completed'
-                  ? {} : (sessionUsageCache.get(usageSessionId) || {});
-                const mergedUsage = {
-                  ...existingUsage,
-                  input_tokens: respUsage?.input_tokens || 0,
-                  output_tokens: respUsage?.output_tokens || 0,
-                  cache_read_input_tokens: respUsage?.cache_read_input_tokens ?? existingUsage.cache_read_input_tokens ?? 0,
-                  cache_creation_input_tokens: respUsage?.cache_creation_input_tokens ?? existingUsage.cache_creation_input_tokens ?? 0,
-                };
+                const existingUsage = sessionUsageCache.get(usageSessionId) || {};
+                const mergedUsage = mergeUsageCapture(existingUsage, respUsage, event === 'response.completed');
                 req.log?.info?.({
                   debug_log: true,
                   reqId: req.id,
@@ -957,7 +923,12 @@ async function getServer(options: RunOptions = {}) {
       // deduction, so we infer the cache hit from the difference between the
       // pre-cache tokenCount (computed by the router) and the reported input_tokens.
       let cacheReadInputTokens = usage?.cache_read_input_tokens ?? 0;
-      const rawInputTokens = usage?.input_tokens ?? req.tokenCount ?? 0;
+      // input_tokens of 0 is not a valid "no data" sentinel (providers report real
+      // zero only in degenerate cases). Use the router's tokenCount estimate when
+      // usage.input_tokens is missing OR zero, so a zeroed usage frame can't wipe
+      // out the input token count for the whole request.
+      const reportedInputTokens = usage?.input_tokens || 0;
+      const rawInputTokens = reportedInputTokens || req.tokenCount || 0;
       if (!cacheReadInputTokens && req.tokenCount && usage?.input_tokens && usage.input_tokens < req.tokenCount) {
         cacheReadInputTokens = req.tokenCount - usage.input_tokens;
         if (cacheReadInputTokens) {

--- a/packages/server/src/utils/usage-merge.ts
+++ b/packages/server/src/utils/usage-merge.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure helpers for merging per-frame LLM usage into the per-request usage cache.
+ *
+ * Extracted from index.ts so the merge contract is unit-testable without
+ * standing up the whole Fastify server.
+ */
+
+export function getUsageCacheReadInputTokens(usage: any): number {
+  return (
+    usage?.cache_read_input_tokens ??
+    usage?.input_tokens_details?.cached_tokens ??
+    usage?.prompt_tokens_details?.cached_tokens ??
+    0
+  );
+}
+
+export function getUsageCacheCreationInputTokens(usage: any): number {
+  return (
+    usage?.cache_creation_input_tokens ??
+    usage?.input_tokens_details?.cache_creation_tokens ??
+    usage?.input_tokens_details?.cache_write_tokens ??
+    usage?.prompt_tokens_details?.cache_creation_tokens ??
+    usage?.prompt_tokens_details?.cache_write_tokens ??
+    0
+  );
+}
+
+/**
+ * Normalize a raw usage object (from Anthropic, OpenAI Chat Completions, or
+ * OpenAI Responses APIs) into a common shape with input_tokens / output_tokens
+ * / cache_read_input_tokens / cache_creation_input_tokens fields.
+ */
+export function normalizeUsagePayload(usage: any): any {
+  if (!usage || typeof usage !== "object") return undefined;
+
+  return {
+    ...usage,
+    input_tokens: usage.input_tokens ?? usage.prompt_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? usage.completion_tokens ?? 0,
+    cache_read_input_tokens: getUsageCacheReadInputTokens(usage),
+    cache_creation_input_tokens: getUsageCacheCreationInputTokens(usage),
+  };
+}
+
+/**
+ * Merge an incoming usage frame into the previously captured usage for a
+ * request. Fields are merged so that an all-zero frame canNOT overwrite a real
+ * value captured earlier: each field is replaced only when the incoming value
+ * is non-zero.
+ *
+ * Why this matters: some OpenAI-compatible upstreams (e.g. fireworks-hosted
+ * GLM-5.2) report real usage on the first chunk (message_start /
+ * response.created) but emit an all-zero usage object on the trailing
+ * message_delta / response.completed. A plain `{...base, ...incoming}` spread
+ * let those zeros clobber the real input_tokens/output_tokens, leaving the
+ * whole request recorded as 0/0 in usage stats.
+ *
+ * `resetBase` should be true on the first frame of a new response
+ * (message_start / response.completed) so stale fields from a previous request
+ * in the same session don't leak in.
+ */
+export function mergeUsageCapture(existing: any, incoming: any, resetBase: boolean): any {
+  const base = resetBase ? {} : (existing || {});
+  const inc = incoming || {};
+  return {
+    ...base,
+    input_tokens: inc.input_tokens || base.input_tokens || 0,
+    output_tokens: inc.output_tokens || base.output_tokens || 0,
+    cache_read_input_tokens: inc.cache_read_input_tokens || base.cache_read_input_tokens || 0,
+    cache_creation_input_tokens:
+      inc.cache_creation_input_tokens || base.cache_creation_input_tokens || 0,
+  };
+}

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       typescript:
         specifier: ^5.8.2
         version: 5.8.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@24.7.0)(vite@7.3.0(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0))
 
   packages/server:
     dependencies:
@@ -3048,6 +3051,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
 
@@ -3056,6 +3062,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -3290,6 +3299,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -3501,6 +3539,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -3707,6 +3749,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4482,6 +4528,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -5908,6 +5958,10 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -6081,6 +6135,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -7134,6 +7191,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -7223,6 +7283,9 @@ packages:
     resolution: {integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==}
     engines: {node: '>=12'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
@@ -7240,6 +7303,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
@@ -7421,6 +7487,13 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -7428,6 +7501,10 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -7746,6 +7823,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -7840,6 +7958,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@4.0.1:
@@ -11225,6 +11348,11 @@ snapshots:
     dependencies:
       '@types/node': 24.7.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.7
@@ -11237,6 +11365,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -11527,6 +11657,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@7.3.0(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.0(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -11772,6 +11943,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   astring@1.9.0: {}
 
   async@3.2.6: {}
@@ -12005,6 +12178,8 @@ snapshots:
   caniuse-lite@1.0.30001761: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -12848,6 +13023,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   express@4.22.1:
     dependencies:
@@ -14625,6 +14802,8 @@ snapshots:
 
   obuf@1.1.2: {}
 
+  obug@2.1.3: {}
+
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
@@ -14796,6 +14975,8 @@ snapshots:
   path-to-regexp@3.3.0: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -16003,6 +16184,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -16097,6 +16280,8 @@ snapshots:
 
   srcset@4.0.0: {}
 
+  stackback@0.0.2: {}
+
   state-local@1.0.7: {}
 
   statuses@1.5.0: {}
@@ -16106,6 +16291,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.1.0: {}
 
   streamx@2.23.0:
     dependencies:
@@ -16329,12 +16516,18 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
   tinypool@1.1.1: {}
+
+  tinyrainbow@3.1.0: {}
 
   tmp@0.0.33:
     dependencies:
@@ -16609,6 +16802,34 @@ snapshots:
       terser: 5.44.1
       tsx: 4.21.0
 
+  vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@24.7.0)(vite@7.3.0(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@7.3.0(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.0(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.7.0
+    transitivePeerDependencies:
+      - msw
+
   void-elements@3.1.0: {}
 
   watchpack@2.5.0:
@@ -16771,6 +16992,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@4.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       typescript:
         specifier: ^5.8.2
         version: 5.8.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@24.7.0)(vite@7.3.0(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0))
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## Summary
- Treat configured provider/model routes as invalid when the model no longer exists in the current provider registry
- Validate fallback candidates against the live provider config before sending requests
- Prevent empty provider/model values from polluting the provider health fail pool

## Why
Deleting a model from a model-family route while CCR is running could leave stale provider/model strings in the routing and fallback path. Those stale candidates could fail repeatedly and poison the health pool, causing unrelated fallback models to be skipped as unavailable.

## Test
- pnpm --filter @wengine-ai/llms build