### PR TITLE
ci(docker): make docker-publish manual-only, pin pnpm 11.1.1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,11 @@
 name: Build and Publish Docker Image
 
+# Manual-only for now: the repo has no Docker registry credentials configured
+# (no DOCKER_USERNAME/DOCKER_PASSWORD secrets) and DOCKER_IMAGE still points at
+# the upstream author's namespace, so a tag-push trigger would fail on every
+# release. Re-add the `push: tags: ['v*.*.*']` trigger once a registry target
+# and credentials are set up.
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
 
 env:
@@ -26,10 +28,12 @@ jobs:
         with:
           node-version: 22
 
+      # Pin the exact pnpm version used by ci.yml: the lockfile is pnpm 11
+      # format, and pnpm 10 fails with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.15.1
+          version: 11.1.1
 
       - name: Get version
         id: version


### PR DESCRIPTION
## Summary
- The docker-publish workflow has never succeeded on this fork: **no Docker registry credentials are configured** (repo has zero Actions secrets) and `DOCKER_IMAGE` still points at the upstream author's `musistudio/claude-code-router` namespace. Every `v*.*.*` tag push therefore produced a failing run (latest: the `v2.3.231` release tag; a June 6 manual run failed the same way).
- Remove the tag-push trigger, keep `workflow_dispatch` only, with a comment explaining how to re-enable once a registry target + credentials are decided.
- Pin pnpm to `11.1.1` (matching `ci.yml`): the lockfile is pnpm 11 format and pnpm 10 fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — this was the immediate failure in the `v2.3.231` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)