### PR TITLE
fix(test): make CCR_CONFIG_DIR isolation actually reach workers

### DIFF
--- a/packages/core/src/__tests__/setup.ts
+++ b/packages/core/src/__tests__/setup.ts
@@ -1,17 +1,14 @@
 /**
- * vitest globalSetup — create an isolated temp HOME before tests run so
- * production code that imports HOME_DIR (from @wengine-ai/claude-code-router-shared)
- * writes into a per-run temp directory, never to the user's real
- * ~/.claude-code-router. The directory is cleaned up on teardown.
+ * vitest globalSetup — teardown for the isolated test HOME created in
+ * vitest.config.ts. The dir path is deterministic (ccr-core-test-home under the
+ * OS tmpdir) so this teardown can remove the same directory the workers used.
  */
-import { mkdtempSync, rmSync } from "node:fs";
+import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 export function setup(): () => void {
-  const dir = mkdtempSync(join(tmpdir(), "ccr-test-"));
-  process.env.CCR_CONFIG_DIR = dir;
   return () => {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(join(tmpdir(), "ccr-core-test-home"), { recursive: true, force: true });
   };
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,12 +1,24 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+// Isolated HOME for tests. The temp dir is created at config-load time so its
+// path can be passed through the `env` option, which vitest propagates to every
+// worker. Mutating process.env inside globalSetup does NOT reliably reach worker
+// threads (the prior approach silently left CCR_CONFIG_DIR empty, so HOME_DIR
+// fell back to the user's real ~/.claude-code-router and tests wrote real state).
+// A deterministic path lets the globalSetup teardown clean the same directory.
+const TEST_HOME = path.join(tmpdir(), "ccr-core-test-home");
+rmSync(TEST_HOME, { recursive: true, force: true });
+mkdirSync(TEST_HOME, { recursive: true });
 
 export default defineConfig({
   test: {
     include: ["src/__tests__/**/*.test.ts"],
     globalSetup: ["./src/__tests__/setup.ts"],
     env: {
-      CCR_CONFIG_DIR: "", // placeholder — real path set by globalSetup
+      CCR_CONFIG_DIR: TEST_HOME,
     },
   },
   resolve: {

--- a/packages/shared/src/__tests__/setup.ts
+++ b/packages/shared/src/__tests__/setup.ts
@@ -1,15 +1,13 @@
 /**
- * vitest globalSetup — create an isolated temp HOME before tests run so
- * production code that imports HOME_DIR writes into a per-run temp directory.
+ * vitest globalSetup — teardown for the isolated test HOME created in
+ * vitest.config.ts.
  */
-import { mkdtempSync, rmSync } from "node:fs";
+import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 export function setup(): () => void {
-  const dir = mkdtempSync(join(tmpdir(), "ccr-shared-test-"));
-  process.env.CCR_CONFIG_DIR = dir;
   return () => {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(join(tmpdir(), "ccr-shared-test-home"), { recursive: true, force: true });
   };
 }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from "vitest/config";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Isolated HOME for tests — created at config-load so the path propagates to
+// workers via `env`. See packages/core/vitest.config.ts for the full rationale.
+const TEST_HOME = join(tmpdir(), "ccr-shared-test-home");
+rmSync(TEST_HOME, { recursive: true, force: true });
+mkdirSync(TEST_HOME, { recursive: true });
 
 export default defineConfig({
   test: {
     include: ["src/__tests__/**/*.test.ts"],
     globalSetup: ["./src/__tests__/setup.ts"],
+    env: {
+      CCR_CONFIG_DIR: TEST_HOME,
+    },
   },
 });


### PR DESCRIPTION
## Summary

Fixes a regression from #22: the test-suite HOME isolation was silently broken, so the core/shared test suites ran against the user's real `~/.claude-code-router`.

## Root cause

`vitest.config.ts` set `env: { CCR_CONFIG_DIR: "" }` as a placeholder while `globalSetup` set the real temp path via `process.env`. The `env` config option **overrides** `process.env` for workers, so workers saw `CCR_CONFIG_DIR=""` (empty). `HOME_DIR = process.env.CCR_CONFIG_DIR || realHome` then fell back to the real `~/.claude-code-router`.

Verified empirically: a worker printed `CCR_CONFIG_DIR=[] VITEST=[true]` — empty, not the temp dir.

Consequence: integration tests that exercise `POST /api/config` mocked `writeConfigFile` but NOT `syncGlobalProjectTakeovers`, so they iterated the user's real project list and rewrote project takeover state / `ccr-state.json`.

## Fix

- Create the temp HOME at **config-load time** and pass the real path through the `env` option, which vitest reliably propagates to workers.
- Use a deterministic tmp path (`ccr-core-test-home` / `ccr-shared-test-home`) so the `globalSetup` teardown removes the same directory.
- Removed the broken empty-string `env` placeholder.

## Verification

- Worker now resolves `CCR_CONFIG_DIR=/var/folders/.../ccr-core-test-home`, `leaking=false`.
- `pnpm -r --if-present test` — 172 tests pass.
- After the fixed run, no new writes appeared under the real `~/.claude-code-router` (the project-config writes observed were from the live running ccr service, timestamped before the test run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)