### PR TITLE
fix(project): cap takeover context window when project lacks extended context

### DIFF
--- a/packages/core/src/__tests__/opencode-transformer.test.ts
+++ b/packages/core/src/__tests__/opencode-transformer.test.ts
@@ -58,7 +58,7 @@ describe("OpenCodeTransformer", () => {
     expect((OpenCodeTransformer as any).TransformerName).toBe("opencode");
   });
 
-  it("should clean cache_control from messages in transformRequestIn", async () => {
+  it("should preserve cache_control markers in transformRequestIn (opencode zen gates its prompt cache on them)", async () => {
     const t = new OpenCodeTransformer();
     const request = makeRequest({
       messages: [
@@ -74,10 +74,40 @@ describe("OpenCodeTransformer", () => {
     const result = await t.transformRequestIn(request, makeProvider("https://opencode.ai"), {});
     const msg = result.messages[0];
     if (Array.isArray(msg.content)) {
-      msg.content.forEach((item: any) => {
-        expect(item.cache_control).toBeUndefined();
-      });
+      const textItem = (msg.content as any[]).find((i: any) => i.type === "text");
+      expect(textItem.cache_control).toEqual({ type: "ephemeral" });
     }
+  });
+
+  it("should preserve cache_control through the Anthropic→Unified→OpenCode chain", async () => {
+    // The full chain: Claude Code sends Anthropic format with cache_control on
+    // system blocks; anthropic.transformer converts to unified; opencode must
+    // not strip the markers on the way to the upstream.
+    const anthropicTransformer = new AnthropicTransformer();
+    const anthropicRequest = {
+      model: "glm-5.2",
+      max_tokens: 4096,
+      stream: true,
+      system: [
+        { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+      ],
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    const unified = await anthropicTransformer.transformRequestOut(anthropicRequest as any);
+    const t = new OpenCodeTransformer();
+    const processed = await t.transformRequestIn(
+      unified,
+      makeProvider("https://opencode.ai/zen/go/v1/chat/completions"),
+      {}
+    );
+
+    const sysMsg = processed.messages.find((m) => m.role === "system");
+    expect(sysMsg).toBeDefined();
+    const block = Array.isArray(sysMsg!.content)
+      ? (sysMsg!.content as any[]).find((i: any) => i.type === "text")
+      : null;
+    expect(block?.cache_control).toEqual({ type: "ephemeral" });
   });
 
   it("should clean media_type from image_url in transformRequestIn", async () => {
@@ -204,5 +234,65 @@ describe("End-to-end: Anthropic request → OpenCode provider tools format", () 
     // Verify the old Anthropic format fields are NOT present at top level
     expect(parsed.tools[0].name).toBeUndefined();
     expect(parsed.tools[0].input_schema).toBeUndefined();
+  });
+});
+
+describe("OpenAI-compatible usage cache mapping", () => {
+  // convertOpenAIResponseToAnthropic reads context.req.id and this.logger.debug.
+  const ctx = { req: { id: "test-req" } } as any;
+  const noopLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+  function makeTransformer(): AnthropicTransformer {
+    const t = new AnthropicTransformer();
+    t.logger = noopLogger;
+    return t;
+  }
+  // anthropic.transformer maps upstream OpenAI-style usage to Anthropic
+  // semantics. Cache reads arrive as prompt_tokens_details.cached_tokens OR
+  // DeepSeek-style prompt_cache_hit_tokens; both must surface as
+  // cache_read_input_tokens with input_tokens net of cache.
+  function makeNonStreamingResponse(usage: any): Response {
+    return new Response(
+      JSON.stringify({
+        id: "chatcmpl-1",
+        model: "deepseek-v4-flash",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          },
+        ],
+        usage,
+      }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  it("maps prompt_tokens_details.cached_tokens (non-streaming)", async () => {
+    const t = makeTransformer();
+    const res = makeNonStreamingResponse({
+      prompt_tokens: 1000,
+      completion_tokens: 5,
+      prompt_tokens_details: { cached_tokens: 800 },
+    });
+    const out = await t.transformResponseIn(res, ctx);
+    const data = await (out as Response).json();
+    expect(data.usage.cache_read_input_tokens).toBe(800);
+    expect(data.usage.input_tokens).toBe(200);
+  });
+
+  it("maps DeepSeek-style prompt_cache_hit_tokens when cached_tokens is absent (non-streaming)", async () => {
+    const t = makeTransformer();
+    const res = makeNonStreamingResponse({
+      prompt_tokens: 1000,
+      completion_tokens: 5,
+      prompt_cache_hit_tokens: 600,
+      prompt_cache_miss_tokens: 400,
+    });
+    const out = await t.transformResponseIn(res, ctx);
+    const data = await (out as Response).json();
+    expect(data.usage.cache_read_input_tokens).toBe(600);
+    expect(data.usage.input_tokens).toBe(400);
   });
 });

--- a/packages/core/src/__tests__/proxy-config-save.test.ts
+++ b/packages/core/src/__tests__/proxy-config-save.test.ts
@@ -1,8 +1,22 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getClaudeProjectId,
+  getClaudeSettingsLocalPath,
+  getProjectConfigDir,
+  setCcrTakeover,
+  writeProjectConfig,
+} from "@wengine-ai/claude-code-router-shared";
 import Server from "../server";
 import { registerAdminRoutes } from "../ccr/admin-routes";
 import { sessionUsageCache } from "../utils/cache";
 import { closeProxyDispatchers } from "../services/proxy";
+
+const { readConfigFileMock } = vi.hoisted(() => ({
+  readConfigFileMock: vi.fn(),
+}));
 
 // POST /api/config normally persists to ~/.claude-code-router/config.json.
 // Keep this route test hermetic so accepted payloads can never overwrite a
@@ -12,6 +26,7 @@ vi.mock("../ccr/config", async (importOriginal) => {
   return {
     ...actual,
     backupConfigFile: vi.fn().mockResolvedValue(null),
+    readConfigFile: readConfigFileMock,
     writeConfigFile: vi.fn().mockResolvedValue(undefined),
   };
 });
@@ -48,9 +63,15 @@ async function buildAdminRuntime() {
 
 describe("POST /api/config proxy URL validation", () => {
   let server: Server;
+  const projectPaths: string[] = [];
 
   afterEach(async () => {
     sessionUsageCache.delete("claude-code:session:proxy-config-save");
+    readConfigFileMock.mockReset();
+    for (const projectPath of projectPaths.splice(0)) {
+      rmSync(getProjectConfigDir(projectPath), { recursive: true, force: true });
+      rmSync(projectPath, { recursive: true, force: true });
+    }
     await closeProxyDispatchers();
     if (server) {
       await server.app.close();
@@ -143,5 +164,52 @@ describe("POST /api/config proxy URL validation", () => {
       // it passed (write/reload errors are tolerated and surface as 200).
       expect(res.statusCode, `proxyUrl=${proxyUrl}`).not.toBe(400);
     }
+  });
+
+  it("refreshes Claude Code takeover after saving a non-empty project Router", async () => {
+    ({ server } = await buildAdminRuntime());
+    const projectPath = mkdtempSync(join(tmpdir(), "ccr-project-route-save-"));
+    projectPaths.push(projectPath);
+    const globalConfig = {
+      APIKEY: "global-key",
+      PORT: 4567,
+      ContextWindow: 400000,
+      Providers: [],
+      Router: {
+        families: {
+          opus: {
+            default: "provider,global-opus",
+            extendedContext: "provider,global-extended",
+            enableExtendedContext: true,
+          },
+        },
+      },
+    };
+    readConfigFileMock.mockResolvedValue(globalConfig);
+
+    await writeProjectConfig(projectPath, { Router: {} });
+    await setCcrTakeover(projectPath, true, globalConfig);
+    expect(
+      JSON.parse(readFileSync(getClaudeSettingsLocalPath(projectPath), "utf8")).env
+        .CLAUDE_CODE_AUTO_COMPACT_WINDOW
+    ).toBe("400000");
+
+    const projectRouter = {
+      enableFamilyRouting: true,
+      families: {
+        opus: { default: "provider,project-opus" },
+      },
+    };
+    const res = await server.app.inject({
+      method: "PUT",
+      url: `/api/projects/${getClaudeProjectId(projectPath)}`,
+      payload: { Router: projectRouter },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const settings = JSON.parse(readFileSync(getClaudeSettingsLocalPath(projectPath), "utf8"));
+    expect(settings.env.ANTHROPIC_MODEL).toBe("ccr-opus");
+    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("ccr-opus");
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
   });
 });

--- a/packages/core/src/ccr/admin-routes.ts
+++ b/packages/core/src/ccr/admin-routes.ts
@@ -50,6 +50,7 @@ import {
   deleteProjectConfig,
   getClaudeProjectId,
   getProjectConfigPath,
+  refreshCcrProjectTakeover,
   refreshProjectTakeovers,
   syncGlobalProjectTakeovers,
   getProjectTakeoverClients,
@@ -482,10 +483,11 @@ export async function registerAdminRoutes(server: any, config: any): Promise<any
       }
 
       await writeProjectConfig(existing.path, { Router });
-      const usesGlobalRouter = Object.keys(Router).length === 0;
-      if (usesGlobalRouter) {
-        const config = await readConfigFile();
+      const config = await readConfigFile();
+      if (Object.keys(Router).length === 0) {
         await refreshProjectTakeovers(existing.path, config);
+      } else {
+        await refreshCcrProjectTakeover(existing.path, config, Router);
       }
       const ccrTakeoverClients = await getProjectTakeoverClients(existing.path);
       return {

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -567,7 +567,13 @@ export class AnthropicTransformer implements Transformer {
 
                 const choice = chunk.choices?.[0];
                 if (chunk.usage) {
-                  const cachedTokens = chunk.usage?.prompt_tokens_details?.cached_tokens || 0;
+                  // OpenAI-compatible upstreams report cache reads in either
+                  // prompt_tokens_details.cached_tokens or the DeepSeek-style
+                  // prompt_cache_hit_tokens; accept whichever is present.
+                  const cachedTokens =
+                    chunk.usage?.prompt_tokens_details?.cached_tokens ??
+                    chunk.usage?.prompt_cache_hit_tokens ??
+                    0;
                   const promptTokens = chunk.usage?.prompt_tokens || 0;
                   // Keep Anthropic protocol semantics for Claude Code: input_tokens is net of cache reads.
                   const inputTokens = promptTokens - cachedTokens;
@@ -1143,7 +1149,9 @@ export class AnthropicTransformer implements Transformer {
         });
       }
       const cachedTokens =
-        openaiResponse.usage?.prompt_tokens_details?.cached_tokens || 0;
+        openaiResponse.usage?.prompt_tokens_details?.cached_tokens ??
+        openaiResponse.usage?.prompt_cache_hit_tokens ??
+        0;
       const inputTokens =
         (openaiResponse.usage?.prompt_tokens || 0) - cachedTokens;
       const result = {

--- a/packages/core/src/transformer/opencode.transformer.ts
+++ b/packages/core/src/transformer/opencode.transformer.ts
@@ -14,7 +14,12 @@ import { v4 as uuidv4 } from "uuid";
  *   resolved transformer is AnthropicTransformer would trigger bypass mode,
  *   sending Anthropic-format tools ({name,description,input_schema}) to an
  *   OpenAI-compatible API that requires {type:"function",function:{…}}.
- * - Cleans cache_control and Anthropic-specific image_url fields that GLM
+ * - Preserves cache_control markers: the opencode zen upstream implements
+ *   explicit prompt caching gated on Anthropic-style cache_control blocks
+ *   (verified: a stable ~16k-token prefix with markers hits ~98% on the
+ *   second identical request; without markers it never caches). Earlier
+ *   versions stripped them on the assumption the backend ignored the field.
+ * - Cleans Anthropic-specific image_url media_type fields that GLM
  *   does not understand.
  * - Converts reasoning_content in streaming/non-streaming responses to the
  *   thinking format expected by Claude Code.
@@ -30,14 +35,12 @@ export class OpenCodeTransformer implements Transformer {
   async transformRequestIn(
     request: UnifiedChatRequest
   ): Promise<UnifiedChatRequest> {
-    // Clean cache_control and Anthropic-specific media_type from messages.
-    // GLM/OpenAI-compatible APIs do not support these fields.
+    // Clean Anthropic-specific media_type from image_url parts. cache_control
+    // markers are deliberately PRESERVED: the opencode zen backend gates its
+    // prompt cache on them (see class doc).
     request.messages.forEach((msg) => {
       if (Array.isArray(msg.content)) {
         msg.content.forEach((item: any) => {
-          if (item.cache_control) {
-            delete item.cache_control;
-          }
           if (item.type === "image_url") {
             if (!item.image_url.url.startsWith("http")) {
               item.image_url.url = `data:${item.media_type};base64,${item.image_url.url}`;
@@ -45,8 +48,6 @@ export class OpenCodeTransformer implements Transformer {
             delete item.media_type;
           }
         });
-      } else if (msg.cache_control) {
-        delete msg.cache_control;
       }
     });
 

--- a/packages/shared/src/__tests__/auto-compact-state.test.ts
+++ b/packages/shared/src/__tests__/auto-compact-state.test.ts
@@ -39,6 +39,22 @@ function deleteState(projectPath: string): void {
   if (existsSync(statePath)) rmSync(statePath, { force: true });
 }
 
+function makeConfig(
+  contextWindow = 400000,
+  router: Record<string, any> = {
+    families: {
+      opus: { default: "provider,opus", enableExtendedContext: true },
+    },
+  },
+): Record<string, any> {
+  return {
+    ContextWindow: contextWindow,
+    APIKEY: "test",
+    PORT: 3456,
+    Router: router,
+  };
+}
+
 function makeSettings(window?: string): { env: Record<string, any> } {
   const env: Record<string, any> = {};
   if (window !== undefined) env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = window;
@@ -58,7 +74,7 @@ describe("auto-compact window state guard", () => {
     // ccr-state.json) whose global ContextWindow later moved to 400000. The stale
     // 200000 must be re-adopted as managed and updated to 400000.
     const projectPath = createProject();
-    const config = { ContextWindow: 400000, APIKEY: "test", PORT: 3456 };
+    const config = makeConfig();
     const settings = makeSettings("200000");
 
     deleteState(projectPath);
@@ -73,7 +89,7 @@ describe("auto-compact window state guard", () => {
 
   it("writes the global value and builds state when the field is absent", () => {
     const projectPath = createProject();
-    const config = { ContextWindow: 400000, APIKEY: "test", PORT: 3456 };
+    const config = makeConfig();
     const settings = makeSettings();
 
     deleteState(projectPath);
@@ -87,7 +103,7 @@ describe("auto-compact window state guard", () => {
 
   it("updates normally when the current value matches the last written value", () => {
     const projectPath = createProject();
-    const config = { ContextWindow: 420000, APIKEY: "test", PORT: 3456 };
+    const config = makeConfig(420000);
     const settings = makeSettings("400000");
 
     writeState(projectPath, { autoCompactWindow: "400000" });
@@ -101,7 +117,7 @@ describe("auto-compact window state guard", () => {
     // The original v2.3.22 guarantee: with a recorded state, a value that differs
     // from what CCR last wrote is treated as a user customization and left alone.
     const projectPath = createProject();
-    const config = { ContextWindow: 400000, APIKEY: "test", PORT: 3456 };
+    const config = makeConfig();
     const settings = makeSettings("350000");
 
     writeState(projectPath, { autoCompactWindow: "200000" });
@@ -112,9 +128,112 @@ describe("auto-compact window state guard", () => {
     expect(readState(projectPath)?.autoCompactWindow).toBe("200000");
   });
 
+  it("caps a non-extended project family at 200000 and removes stale [1m] aliases", () => {
+    const projectPath = createProject();
+    const config = makeConfig(400000, {
+      families: {
+        opus: { default: "provider,opus", enableExtendedContext: false },
+      },
+    });
+    const settings = makeSettings();
+    settings.env.ANTHROPIC_MODEL = "ccr-opus[1m]";
+    settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "ccr-opus[1m]";
+
+    applyCcrProjectTakeover(settings, config, projectPath);
+
+    expect(settings.env.ANTHROPIC_MODEL).toBe("ccr-opus");
+    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("ccr-opus");
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
+    expect(readState(projectPath)?.autoCompactWindow).toBe("200000");
+  });
+
+  it("keeps the configured window when the project default family enables extended context", () => {
+    const projectPath = createProject();
+    const config = makeConfig(400000);
+    const settings = makeSettings();
+
+    applyCcrProjectTakeover(settings, config, projectPath);
+
+    expect(settings.env.ANTHROPIC_MODEL).toBe("ccr-opus[1m]");
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("400000");
+  });
+
+  it("uses the top-level extended context flag when family routing is absent", () => {
+    const extendedProjectPath = createProject();
+    const extendedSettings = makeSettings();
+    applyCcrProjectTakeover(
+      extendedSettings,
+      makeConfig(400000, { enableExtendedContext: true, extendedContext: "provider,extended" }),
+      extendedProjectPath,
+    );
+
+    const standardProjectPath = createProject();
+    const standardSettings = makeSettings();
+    applyCcrProjectTakeover(
+      standardSettings,
+      makeConfig(400000, { default: "provider,default" }),
+      standardProjectPath,
+    );
+
+    expect(extendedSettings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("400000");
+    expect(standardSettings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
+    expect(standardSettings.env.ANTHROPIC_MODEL).toBeUndefined();
+  });
+
+  it("updates a previously managed extended window when the project disables extended context", () => {
+    const projectPath = createProject();
+    const config = makeConfig(400000, {
+      families: {
+        opus: { default: "provider,opus" },
+      },
+    });
+    const settings = makeSettings("400000");
+
+    writeState(projectPath, { autoCompactWindow: "400000" });
+    applyCcrProjectTakeover(settings, config, projectPath);
+
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
+    expect(readState(projectPath)?.autoCompactWindow).toBe("200000");
+  });
+
+  it("records the stale extended window when state is missing and the project is capped", () => {
+    const projectPath = createProject();
+    const config = makeConfig(400000, {
+      families: {
+        opus: { default: "provider,opus" },
+      },
+    });
+    const settings = makeSettings("400000");
+
+    deleteState(projectPath);
+    applyCcrProjectTakeover(settings, config, projectPath);
+
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
+    expect(readState(projectPath)).toMatchObject({
+      autoCompactWindow: "200000",
+      previousAutoCompactWindow: "400000",
+    });
+  });
+
+  it("preserves a divergent user window even when the project is capped", () => {
+    const projectPath = createProject();
+    const config = makeConfig(400000, {
+      families: {
+        opus: { default: "provider,opus" },
+      },
+    });
+    const settings = makeSettings("350000");
+
+    writeState(projectPath, { autoCompactWindow: "400000" });
+    applyCcrProjectTakeover(settings, config, projectPath);
+
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("350000");
+    expect(readState(projectPath)?.autoCompactWindow).toBe("400000");
+  });
+
   it("removes the window on disable when it still matches the managed value, and clears state", () => {
     const projectPath = createProject();
-    const config = { ContextWindow: 400000, APIKEY: "test", PORT: 3456 };
+    const config = makeConfig();
     const settings = makeSettings("400000");
 
     writeState(projectPath, { autoCompactWindow: "400000" });
@@ -124,9 +243,24 @@ describe("auto-compact window state guard", () => {
     expect(readState(projectPath)).toBeNull();
   });
 
+  it("removes the capped window on disable when state is missing", () => {
+    const projectPath = createProject();
+    const config = makeConfig(400000, {
+      families: {
+        opus: { default: "provider,opus" },
+      },
+    });
+    const settings = makeSettings("200000");
+
+    deleteState(projectPath);
+    removeCcrProjectTakeover(settings, projectPath, config);
+
+    expect(settings.env?.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined();
+  });
+
   it("keeps a divergent user value on disable", () => {
     const projectPath = createProject();
-    const config = { ContextWindow: 400000, APIKEY: "test", PORT: 3456 };
+    const config = makeConfig();
     const settings = makeSettings("350000");
 
     writeState(projectPath, { autoCompactWindow: "400000" });

--- a/packages/shared/src/__tests__/auto-compact-state.test.ts
+++ b/packages/shared/src/__tests__/auto-compact-state.test.ts
@@ -180,6 +180,27 @@ describe("auto-compact window state guard", () => {
     expect(standardSettings.env.ANTHROPIC_MODEL).toBeUndefined();
   });
 
+  it("ignores stale family enableExtendedContext when family routing is disabled", () => {
+    // enableFamilyRouting=false means the runtime bypasses family routing and
+    // falls through to a non-extended top-level route. A leftover
+    // families.opus.enableExtendedContext=true must NOT keep the managed window
+    // above 200000, or the request would overflow once context passes 200k.
+    const projectPath = createProject();
+    const config = makeConfig(400000, {
+      enableFamilyRouting: false,
+      default: "provider,default",
+      families: {
+        opus: { default: "provider,opus", enableExtendedContext: true },
+      },
+    });
+    const settings = makeSettings();
+
+    applyCcrProjectTakeover(settings, config, projectPath);
+
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
+    expect(settings.env.ANTHROPIC_MODEL).toBeUndefined();
+  });
+
   it("updates a previously managed extended window when the project disables extended context", () => {
     const projectPath = createProject();
     const config = makeConfig(400000, {

--- a/packages/shared/src/__tests__/project-takeover-sync.test.ts
+++ b/packages/shared/src/__tests__/project-takeover-sync.test.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getClaudeSettingsLocalPath,
+  refreshCcrProjectTakeover,
+  setCcrTakeover,
+  syncGlobalProjectTakeovers,
+  writeProjectConfig,
+} from "../projectConfig";
+import { getProjectConfigDir } from "../constants";
+
+const projectPaths: string[] = [];
+
+function createProject(): string {
+  const projectPath = mkdtempSync(join(tmpdir(), "ccr-project-takeover-sync-"));
+  projectPaths.push(projectPath);
+  return projectPath;
+}
+
+function globalConfig(contextWindow = 400000): Record<string, any> {
+  return {
+    APIKEY: "global-key",
+    PORT: 4567,
+    ContextWindow: contextWindow,
+    Router: {
+      families: {
+        opus: {
+          default: "provider,global-opus",
+          extendedContext: "provider,global-extended",
+          enableExtendedContext: true,
+        },
+      },
+    },
+  };
+}
+
+function projectRouter(extended = false): Record<string, any> {
+  return {
+    enableFamilyRouting: true,
+    families: {
+      opus: {
+        default: "provider,project-opus",
+        ...(extended
+          ? {
+              extendedContext: "provider,project-extended",
+              enableExtendedContext: true,
+            }
+          : {}),
+      },
+    },
+  };
+}
+
+function readSettings(projectPath: string): Record<string, any> {
+  return JSON.parse(readFileSync(getClaudeSettingsLocalPath(projectPath), "utf8"));
+}
+
+afterEach(() => {
+  for (const projectPath of projectPaths.splice(0)) {
+    rmSync(getProjectConfigDir(projectPath), { recursive: true, force: true });
+    rmSync(projectPath, { recursive: true, force: true });
+  }
+});
+
+describe("project takeover Router synchronization", () => {
+  it("uses the authoritative project Router instead of the global family aliases", async () => {
+    const projectPath = createProject();
+    await writeProjectConfig(projectPath, { Router: projectRouter(false) });
+    await setCcrTakeover(projectPath, true, globalConfig());
+
+    const settings = readSettings(projectPath);
+    expect(settings.env.ANTHROPIC_MODEL).toBe("ccr-opus");
+    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("ccr-opus");
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
+    expect(settings.env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:4567");
+    expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe("global-key");
+  });
+
+  it("refreshes a custom Router project immediately after its Router changes", async () => {
+    const projectPath = createProject();
+    await writeProjectConfig(projectPath, { Router: projectRouter(true) });
+    await setCcrTakeover(projectPath, true, globalConfig());
+
+    await writeProjectConfig(projectPath, { Router: projectRouter(false) });
+    expect(await refreshCcrProjectTakeover(projectPath, globalConfig())).toBe(true);
+
+    const settings = readSettings(projectPath);
+    expect(settings.env.ANTHROPIC_MODEL).toBe("ccr-opus");
+    expect(settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
+  });
+
+  it("syncs global and custom Router projects without leaking global extended context", async () => {
+    const globalProject = createProject();
+    const customProject = createProject();
+    await writeProjectConfig(globalProject, { Router: {} });
+    await writeProjectConfig(customProject, { Router: projectRouter(false) });
+    await setCcrTakeover(globalProject, true, globalConfig(300000));
+    await setCcrTakeover(customProject, true, globalConfig(300000));
+
+    const result = await syncGlobalProjectTakeovers(globalConfig(420000));
+
+    expect(result).toMatchObject({ updated: 2, skipped: 0, failed: [] });
+    expect(readSettings(globalProject).env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("420000");
+    expect(readSettings(globalProject).env.ANTHROPIC_MODEL).toBe("ccr-opus[1m]");
+    expect(readSettings(customProject).env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("200000");
+    expect(readSettings(customProject).env.ANTHROPIC_MODEL).toBe("ccr-opus");
+  });
+
+  it("skips custom Router projects without Claude Code takeover", async () => {
+    const projectPath = createProject();
+    await writeProjectConfig(projectPath, { Router: projectRouter(false) });
+    const qwenSettingsPath = join(projectPath, ".qwen", "settings.json");
+    mkdirSync(join(projectPath, ".qwen"), { recursive: true });
+    writeFileSync(qwenSettingsPath, JSON.stringify({ marker: "unchanged" }), {
+      encoding: "utf8",
+      flag: "w",
+    });
+
+    const before = readFileSync(qwenSettingsPath, "utf8");
+    const result = await syncGlobalProjectTakeovers(globalConfig(420000));
+
+    expect(result).toMatchObject({ updated: 0, skipped: 1, failed: [] });
+    expect(readFileSync(qwenSettingsPath, "utf8")).toBe(before);
+  });
+});

--- a/packages/shared/src/client-integrations.ts
+++ b/packages/shared/src/client-integrations.ts
@@ -459,6 +459,33 @@ function hasExtendedContext(familyConfig: any): boolean {
   return familyConfig?.enableExtendedContext === true;
 }
 
+function getSupportedClaudeFamilyNames(config: Record<string, any>): string[] {
+  if (!hasFamiliesConfig(config)) return [];
+
+  const families = config.Router.families;
+  return Object.keys(families).filter(
+    (family) => ["opus", "sonnet", "haiku"].includes(family) && isObject(families[family])
+  );
+}
+
+function getDefaultClaudeFamily(config: Record<string, any>): string | null {
+  const familyNames = getSupportedClaudeFamilyNames(config);
+  if (familyNames.includes("opus")) return "opus";
+  return familyNames[0] || null;
+}
+
+function getClaudeTakeoverContextWindow(config: Record<string, any>): number {
+  const contextWindow = getContextWindow(config);
+  const defaultFamily = getDefaultClaudeFamily(config);
+  const extendedContextEnabled = defaultFamily
+    ? hasExtendedContext(config.Router.families[defaultFamily])
+    : hasExtendedContext(config.Router);
+
+  return extendedContextEnabled
+    ? contextWindow
+    : Math.min(contextWindow, DEFAULT_CONTEXT_WINDOW);
+}
+
 function applyClaudeModelFamilies(settings: Record<string, any>, config: Record<string, any>): void {
   if (!isObject(settings.env)) settings.env = {};
 
@@ -471,10 +498,9 @@ function applyClaudeModelFamilies(settings: Record<string, any>, config: Record<
   if (!hasFamiliesConfig(config)) return;
 
   const families = config.Router.families;
-  const familyNames = Object.keys(families);
-  let primaryFamily: string | null = null;
+  const supportedFamilyNames = getSupportedClaudeFamilyNames(config);
 
-  for (const family of familyNames) {
+  for (const family of supportedFamilyNames) {
     const familyConfig = families[family];
     const extendedSuffix = hasExtendedContext(familyConfig) ? "[1m]" : "";
     const ccrModel = `ccr-${family}${extendedSuffix}`;
@@ -482,35 +508,29 @@ function applyClaudeModelFamilies(settings: Record<string, any>, config: Record<
     switch (family) {
       case "opus":
         settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL = ccrModel;
-        if (!primaryFamily) primaryFamily = "opus";
         break;
       case "sonnet":
         settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL = ccrModel;
-        if (!primaryFamily) primaryFamily = "sonnet";
         break;
       case "haiku":
         settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = ccrModel;
-        if (!primaryFamily) primaryFamily = "haiku";
         break;
     }
   }
 
-  const defaultFamily = families.opus ? "opus" : primaryFamily;
+  const defaultFamily = getDefaultClaudeFamily(config);
   if (defaultFamily) {
     const defaultConfig = families[defaultFamily];
     const extendedSuffix = hasExtendedContext(defaultConfig) ? "[1m]" : "";
     settings.env.ANTHROPIC_MODEL = `ccr-${defaultFamily}${extendedSuffix}`;
   }
 
-  const thinkFamily = familyNames.find((family) => families[family]?.think);
-  if (thinkFamily) {
-    const thinkConfig = families[thinkFamily];
-    const extendedSuffix = hasExtendedContext(thinkConfig) ? "[1m]" : "";
-    settings.env.ANTHROPIC_REASONING_MODEL = `ccr-${thinkFamily}${extendedSuffix}`;
-  } else if (primaryFamily) {
-    const primaryConfig = families[primaryFamily];
-    const extendedSuffix = hasExtendedContext(primaryConfig) ? "[1m]" : "";
-    settings.env.ANTHROPIC_REASONING_MODEL = `ccr-${primaryFamily}${extendedSuffix}`;
+  const thinkFamily = supportedFamilyNames.find((family) => families[family]?.think);
+  const reasoningFamily = thinkFamily || defaultFamily;
+  if (reasoningFamily) {
+    const reasoningConfig = families[reasoningFamily];
+    const extendedSuffix = hasExtendedContext(reasoningConfig) ? "[1m]" : "";
+    settings.env.ANTHROPIC_REASONING_MODEL = `ccr-${reasoningFamily}${extendedSuffix}`;
   }
 }
 
@@ -530,6 +550,7 @@ function applyClaudeAutoCompactSettings(
   settings: Record<string, any>,
   config: Record<string, any>,
   state?: ManagedStateAccess,
+  managedContextWindow?: number,
 ): void {
   settings.autoCompactEnabled = true;
   if (!isObject(settings.env)) settings.env = {};
@@ -553,7 +574,7 @@ function applyClaudeAutoCompactSettings(
   // the displaced old value is recorded into `previousAutoCompactWindow` for
   // audit/recovery. With a present state, a divergent value is still treated as
   // a user customization and left untouched (the original v2.3.22 guarantee).
-  const managedWindow = String(getContextWindow(config));
+  const managedWindow = String(managedContextWindow ?? getContextWindow(config));
   const currentWindow = settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
   const lastWrittenWindow = state?.read().autoCompactWindow;
   const isManaged =
@@ -781,7 +802,12 @@ export function applyCcrProjectTakeover(
   settings.env.ANTHROPIC_BASE_URL = getCcrBaseUrl(config);
   settings.env.ANTHROPIC_AUTH_TOKEN = config.APIKEY || "test";
   applyClaudeModelFamilies(settings, config);
-  applyClaudeAutoCompactSettings(settings, config, projectStateAccess(projectPath));
+  applyClaudeAutoCompactSettings(
+    settings,
+    config,
+    projectStateAccess(projectPath),
+    getClaudeTakeoverContextWindow(config),
+  );
   applyClaudeAttributionHeader(settings, config);
 
   if (config?.StatusLine?.enabled) {
@@ -824,7 +850,7 @@ export function removeCcrProjectTakeover(
     // Always clear the recorded state for this project afterward.
     const lastWrittenWindow = state?.read().autoCompactWindow;
     const currentWindow = settings.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
-    const managedWindow = config ? String(getContextWindow(config)) : undefined;
+    const managedWindow = config ? String(getClaudeTakeoverContextWindow(config)) : undefined;
     const shouldRemove =
       currentWindow === lastWrittenWindow ||
       (lastWrittenWindow === undefined && managedWindow !== undefined && currentWindow === managedWindow);

--- a/packages/shared/src/client-integrations.ts
+++ b/packages/shared/src/client-integrations.ts
@@ -459,7 +459,15 @@ function hasExtendedContext(familyConfig: any): boolean {
   return familyConfig?.enableExtendedContext === true;
 }
 
+// A family is only authoritative when family routing has not been explicitly
+// disabled AND the entry is a supported alias family. When enableFamilyRouting is
+// explicitly false the runtime bypasses family routing entirely, so a stale
+// families.<x>.enableExtendedContext must NOT keep the managed window above
+// 200000 — the request would fall through to a non-extended top-level route and
+// overflow. An undefined enableFamilyRouting preserves the existing takeover
+// behavior (families present ⇒ emit aliases), matching applyClaudeModelFamilies.
 function getSupportedClaudeFamilyNames(config: Record<string, any>): string[] {
+  if (config.Router?.enableFamilyRouting === false) return [];
   if (!hasFamiliesConfig(config)) return [];
 
   const families = config.Router.families;

--- a/packages/shared/src/projectConfig.ts
+++ b/packages/shared/src/projectConfig.ts
@@ -45,6 +45,27 @@ function isUsingGlobalRouter(router: Record<string, any> | undefined): boolean {
   return Object.keys(router || {}).length === 0;
 }
 
+function buildProjectTakeoverConfig(
+  config: Record<string, any>,
+  projectRouter: Record<string, any> | undefined,
+): Record<string, any> {
+  if (isUsingGlobalRouter(projectRouter)) return config;
+  return { ...config, Router: projectRouter };
+}
+
+async function resolveProjectTakeoverConfig(
+  projectPath: string,
+  config: Record<string, any>,
+  projectRouter?: Record<string, any>,
+): Promise<Record<string, any>> {
+  if (projectRouter !== undefined) {
+    return buildProjectTakeoverConfig(config, projectRouter);
+  }
+
+  const projectConfig = await readProjectConfig(projectPath);
+  return buildProjectTakeoverConfig(config, projectConfig?.Router);
+}
+
 /**
  * Read the project-level config for a given project path.
  * Returns null if no project-level config has been created yet.
@@ -190,6 +211,7 @@ function getCcrTakeoverBackupPath(projectPath: string): string {
 export async function setCcrTakeover(projectPath: string, enabled: boolean, config: Record<string, any>): Promise<void> {
   const settingsPath = getClaudeSettingsLocalPath(projectPath);
   const backupPath = getCcrTakeoverBackupPath(projectPath);
+  const takeoverConfig = await resolveProjectTakeoverConfig(projectPath, config);
   let settings = await readClaudeSettingsLocal(projectPath);
 
   if (enabled) {
@@ -202,7 +224,7 @@ export async function setCcrTakeover(projectPath: string, enabled: boolean, conf
     } catch {
       // No usable backup, start from the current settings.
     }
-    applyCcrProjectTakeover(settings, config, projectPath);
+    applyCcrProjectTakeover(settings, takeoverConfig, projectPath);
   } else {
     // Snapshot the pre-removal active state, then strip ccr-managed fields
     // (including the auto-compact window CCR owns) before backing up. The backup
@@ -212,7 +234,7 @@ export async function setCcrTakeover(projectPath: string, enabled: boolean, conf
     // avoids a stale managed window being restored later and mistaken for a user
     // value (which would freeze it and stop ContextWindow changes from applying).
     const wasActive = isCcrProjectTakeoverActive(settings);
-    removeCcrProjectTakeover(settings, projectPath, config);
+    removeCcrProjectTakeover(settings, projectPath, takeoverConfig);
     if (wasActive) {
       await fs.mkdir(path.dirname(backupPath), { recursive: true });
       await fs.writeFile(backupPath, JSON.stringify(settings, null, 2), "utf-8");
@@ -228,13 +250,18 @@ export async function setCcrTakeover(projectPath: string, enabled: boolean, conf
  * from the current global config. Returns false when the project is not
  * currently under ccr takeover.
  */
-export async function refreshCcrProjectTakeover(projectPath: string, config: Record<string, any>): Promise<boolean> {
+export async function refreshCcrProjectTakeover(
+  projectPath: string,
+  config: Record<string, any>,
+  projectRouter?: Record<string, any>,
+): Promise<boolean> {
   const settings = await readClaudeSettingsLocal(projectPath);
   if (!isCcrProjectTakeoverActive(settings)) {
     return false;
   }
 
-  applyCcrProjectTakeover(settings, config, projectPath);
+  const takeoverConfig = await resolveProjectTakeoverConfig(projectPath, config, projectRouter);
+  applyCcrProjectTakeover(settings, takeoverConfig, projectPath);
   const settingsPath = getClaudeSettingsLocalPath(projectPath);
   await fs.mkdir(path.dirname(settingsPath), { recursive: true });
   await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
@@ -321,26 +348,21 @@ export async function refreshProjectTakeovers(
 }
 
 /**
- * Refresh `.claude/settings.local.json` for projects that are both:
- * - following the global Router (`Router: {}` in their project config), and
- * - currently under ccr takeover.
- *
- * This keeps client-side managed fields (model aliases, auto-compact window,
- * statusline, proxy URL/token) aligned after the global config changes without
- * touching projects that have local Router overrides or disabled takeover.
+ * Refresh project-scoped takeover settings after the global config changes.
+ * Projects following the global Router refresh every active client. Projects
+ * with an authoritative local Router refresh only Claude Code, so global
+ * connection/context settings propagate without leaking global model aliases
+ * into the project or changing other clients' existing project semantics.
  */
 export async function syncGlobalProjectTakeovers(config: Record<string, any>): Promise<ProjectTakeoverSyncResult> {
   const result: ProjectTakeoverSyncResult = { updated: 0, skipped: 0, failed: [] };
   const projects = await listProjectConfigs();
 
   for (const project of projects) {
-    if (!isUsingGlobalRouter(project.Router)) {
-      result.skipped++;
-      continue;
-    }
-
     try {
-      const updated = await refreshProjectTakeovers(project.path, config);
+      const updated = isUsingGlobalRouter(project.Router)
+        ? await refreshProjectTakeovers(project.path, config)
+        : await refreshCcrProjectTakeover(project.path, config, project.Router);
       if (!updated) {
         result.skipped++;
         continue;


### PR DESCRIPTION
## Problem

### 1. Project takeover ignored the project Router for the context window

Project-level Claude Code takeover wrote `.claude/settings.local.json` using only the global Router and global `ContextWindow`, never consulting the project's own authoritative Router. When the global default family enabled `[1m]` and `ContextWindow > 200000` but the project Router did **not** enable extended context, the project kept `[1m]` aliases and a `>200k` auto-compact window. Once context passed 200k, strict project routing could not escape to the global extended model, leaving the project with **no usable model**.

### 2. opencode go never hit the prompt cache

Requests routed to the opencode zen backend reported `cached_tokens: 0` on every request. Verified directly against the upstream:

- **Without** `cache_control` markers: a stable ~16k-token prefix sent repeatedly never caches (`cached_tokens` stays 0).
- **With** Anthropic-style `cache_control` blocks: `15616/15885` (~98%) cache reads from the second identical request on.

Root cause: `OpenCodeTransformer.transformRequestIn` stripped every `cache_control` marker on the way upstream (based on the assumption the backend ignores the field), so the upstream's explicit-marker cache never engaged.

## Fix

### Project takeover context window

- **Effective takeover config**: compose a takeover-only config (global connection/UI fields + project Router) so project takeover honors the project Router without leaking global families/fallback into the project.
- **Cap context window**: cap the CCR-managed `CLAUDE_CODE_AUTO_COMPACT_WINDOW` at `200000` when the project's default family (opus-preferred, else first configured family; ignored when `enableFamilyRouting === false`) or top-level `enableExtendedContext` is off; preserve the global `ContextWindow` when extended context is enabled. User hand-written divergent windows stay preserved; managed-state and `previousAutoCompactWindow` audit intact.
- **Refresh coverage**: refresh Claude Code takeover after saving a non-empty project Router (`PUT /api/projects/:id`) and during `syncGlobalProjectTakeovers`, so global connection/context changes propagate without expanding scope to pi/qwen/opencode project semantics.

### opencode cache

- **Preserve `cache_control`**: `OpenCodeTransformer.transformRequestIn` keeps cache_control markers (only the Anthropic-specific `image_url.media_type` is still cleaned). Class doc records the verified upstream behavior.
- **DeepSeek-style usage mapping**: `AnthropicTransformer` now accepts `prompt_cache_hit_tokens` as a fallback when `prompt_tokens_details.cached_tokens` is absent, in both the streaming (`message_delta` merge) and non-streaming OpenAI→Anthropic conversions, so DeepSeek-style upstreams report cache reads correctly.

## Files

- `packages/shared/src/client-integrations.ts` — `getSupportedClaudeFamilyNames`, `getDefaultClaudeFamily`, `getClaudeTakeoverContextWindow`; `applyClaudeModelFamilies` only iterates configured opus/sonnet/haiku; `applyClaudeAutoCompactSettings` gains `managedContextWindow` param; `removeCcrProjectTakeover` uses the same window rule.
- `packages/shared/src/projectConfig.ts` — `buildProjectTakeoverConfig` / `resolveProjectTakeoverConfig`; `setCcrTakeover` and `refreshCcrProjectTakeover` (new optional `projectRouter` arg) use the effective config; `syncGlobalProjectTakeovers` no longer skips custom-Router projects.
- `packages/core/src/ccr/admin-routes.ts` — `PUT /api/projects/:id` refreshes Claude Code takeover for non-empty Routers too.
- `packages/core/src/transformer/opencode.transformer.ts` — stop stripping `cache_control`; doc update.
- `packages/core/src/transformer/anthropic.transformer.ts` — cache usage mapping fallback (`cached_tokens ?? prompt_cache_hit_tokens`), streaming + non-streaming.

## Tests

- Extended `packages/shared/src/__tests__/auto-compact-state.test.ts`: cap at 200k without extended context; preserve global window with extended context; top-level flag; ignore stale family flag when family routing disabled; stale-state migration; divergent user window preserved; disable removes only matching managed value.
- Added `packages/shared/src/__tests__/project-takeover-sync.test.ts`: project Router takes precedence over global aliases; refresh after Router change; `syncGlobalProjectTakeovers` updates both global-Router and custom-Router projects without leaking extended context; custom-Router project without Claude Code takeover is left untouched.
- Added regression in `packages/core/src/__tests__/proxy-config-save.test.ts`: `PUT /api/projects/:id` with a non-empty Router switches takeover from `[1m]`/400k to `ccr-opus`/200k.
- Updated `packages/core/src/__tests__/opencode-transformer.test.ts`: flipped the old "strip cache_control" assertion into "preserve"; added an Anthropic→Unified→OpenCode chain test asserting markers survive; added two usage-mapping cases (`cached_tokens` and `prompt_cache_hit_tokens`, `input_tokens` net of cache).

All tests use the Vitest isolated HOME and temp project paths; no running global `ccr` was touched.

## Verification

- `pnpm --filter @wengine-ai/claude-code-router-shared test` → 22/22
- `pnpm --filter @wengine-ai/llms test` → 225/225
- opencode zen cache behavior confirmed by direct upstream probes (documented above), independent of CCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)