### PR TITLE
fix(usage): non-stream records skew TTFT and inflate tokens/sec

### DIFF
--- a/packages/core/src/__tests__/usage-summary-sql.test.ts
+++ b/packages/core/src/__tests__/usage-summary-sql.test.ts
@@ -181,3 +181,46 @@ describe("SQL usage summary", () => {
     expect(result.summary.byProvider.providerB).toBeUndefined();
   });
 });
+
+describe("non-stream ttft/tps semantics", () => {
+  // Non-streaming responses arrive as one payload: TTFT is meaningless and
+  // must stay null; speed is tokens over total duration (no decode-phase
+  // subtraction, no 1s-clamp inflation).
+  it("keeps ttft null for non-stream records and computes tps over total duration", () => {
+    const records = query({ provider: "providerNS" });
+    const before = records.total;
+    const summaryBefore = querySummary();
+
+    append(makeRecord({
+      id: "ns-1",
+      provider: "providerNS",
+      stream: false,
+      ttft: null,
+      outputTokens: 100,
+      durationMs: 50000,
+    }));
+    append(makeRecord({
+      id: "ns-2",
+      provider: "providerNS",
+      stream: false,
+      // Simulate a stale writer that still reports duration-as-TTFT for
+      // non-stream requests — normalization must not let it clamp the
+      // decode window to 1s and report 100 tok/s.
+      ttft: 50000,
+      outputTokens: 100,
+      durationMs: 50000,
+    }));
+
+    const rows = query({ provider: "providerNS", page: 1, pageSize: 10 });
+    expect(rows.total - before).toBe(2);
+    expect(rows.records.filter((r: any) => r.id === "ns-1")[0].ttft).toBeNull();
+    expect(rows.records.filter((r: any) => r.id === "ns-1")[0].tokensPerSecond).toBe(2);
+    // Stale duration-as-TTFT input on a non-stream record is stripped to null.
+    expect(rows.records.filter((r: any) => r.id === "ns-2")[0].ttft).toBeNull();
+    expect(rows.records.filter((r: any) => r.id === "ns-2")[0].tokensPerSecond).toBe(2);
+
+    // avgTtft ignores non-stream rows; only pre-seeded stream rows count.
+    const after = querySummary();
+    expect(after.avgTtft).toBe(summaryBefore.avgTtft);
+  });
+});

--- a/packages/core/src/ccr/request-pipeline.ts
+++ b/packages/core/src/ccr/request-pipeline.ts
@@ -610,7 +610,11 @@ export function registerRequestPipeline(serverInstance: any, config: any): void 
         outputTokens,
         cacheReadInputTokens,
         cacheCreationInputTokens: usage?.cache_creation_input_tokens || 0,
-        ttft: isFailedRequest ? null : speedStats.ttft,
+        // TTFT is only meaningful for streaming requests — a non-streaming
+        // response arrives as one payload, so "first token" equals total
+        // duration. Keep non-stream TTFT null so it neither pollutes the
+        // per-record display nor the avgTtft aggregate.
+        ttft: isFailedRequest || !req.body?.stream ? null : speedStats.ttft,
         tokensPerSecond: isFailedRequest ? null : speedStats.tokensPerSecond,
         durationMs: req.requestStartTime
           ? Math.round(performance.now() - req.requestStartTime)

--- a/packages/core/src/ccr/usage-store.ts
+++ b/packages/core/src/ccr/usage-store.ts
@@ -305,7 +305,11 @@ function normalizeUsageRecord(record: UsageRecord): UsageRecord {
   const outputTokens = Number(record.outputTokens) || 0;
   const rawDurationMs = Number(record.durationMs);
   const durationMs = Number.isFinite(rawDurationMs) ? rawDurationMs : null;
-  const ttft = parseNumericTokenSpeedValue(record.ttft);
+  // TTFT is only meaningful for streaming requests: a non-streaming response
+  // arrives as one payload where "first token" equals total duration. Force
+  // non-stream TTFT to null regardless of what the caller supplied, so it
+  // cannot pollute per-record display or the avgTtft aggregate.
+  const ttft = record.stream ? parseNumericTokenSpeedValue(record.ttft) : null;
 
   return {
     ...record,

--- a/packages/core/src/plugins/token-speed.ts
+++ b/packages/core/src/plugins/token-speed.ts
@@ -402,9 +402,12 @@ export const tokenSpeedPlugin: CCRPlugin = {
 
       // Only output stats if token count was available
       if (hasTokenCount) {
-        const ttft = Math.round(endTime - startTime);
         const totalDuration = endTime - startTime;
 
+        // Non-streaming responses deliver the whole payload at once, so there
+        // is no observable first-token moment — reporting total duration as
+        // TTFT would be misleading. Leave TTFT unset; compute speed as
+        // tokens over total duration (no decode-phase subtraction).
         const stats: TokenStats = {
           requestId,
           sessionId,
@@ -412,7 +415,6 @@ export const tokenSpeedPlugin: CCRPlugin = {
           lastTokenTime: endTime,
           tokenCount,
           tokensPerSecond: calculateFinalTokensPerSecond(tokenCount, totalDuration),
-          timeToFirstToken: ttft,
           stream: false
         };
 


### PR DESCRIPTION
## Problem

Non-streaming requests (e.g. Claude Code's streaming→non-streaming fallback retry) were recorded with bogus speed stats:

- **TTFT**: the token-speed plugin reported total duration as "time to first token" for non-stream responses (first byte IS the whole payload), so every non-stream record showed TTFT ≈ duration (often 100s+).
- **tokens/sec**: `normalizeUsageRecord` computes the decode window as `duration - ttft`, which collapses to ~0 for non-stream records and hits the `MIN_DECODE_DURATION_SECONDS = 1` floor — recording `tokens_per_second == output_tokens`. Example from real data: 3674 tok/s on a request that took 109s (real rate ~34 tok/s).
- **avgTtft aggregate** mixed these fake TTFTs into the streaming average.

## Fix

TTFT is only meaningful for streaming requests; non-stream speed is tokens over total duration.

- `plugins/token-speed.ts`: non-stream branch no longer emits duration-as-TTFT
- `ccr/request-pipeline.ts`: force `ttft=null` on non-stream usage records at capture time
- `ccr/usage-store.ts`: `normalizeUsageRecord` strips `ttft` for `stream=false` records regardless of which writer supplied it (covers jsonl migration path), so `avgTtft` aggregates only real streaming TTFT. With ttft=null the decode subtraction becomes 0 and tps naturally equals output/duration.

## Verification

- New test block in `usage-summary-sql.test.ts`: non-stream ttft stays null, tps = tokens/duration (100 tokens / 50s = 2 t/s), stale duration-as-TTFT input is stripped, avgTtft unchanged by non-stream rows
- Full core suite: 229/229 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)