### PR TITLE
fix(ui): parse transformer parameter values as JSON/boolean/number

### DIFF
--- a/packages/core/src/__tests__/ui-params.test.ts
+++ b/packages/core/src/__tests__/ui-params.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+// UI util is pure TS with no React deps — test it from the core suite where
+// vitest is already configured.
+import { parseParamValue, formatParamValue } from "../../../ui/src/utils/params";
+
+describe("parseParamValue", () => {
+  it("parses nested JSON objects", () => {
+    expect(parseParamValue('{"reasoning":{"enabled":true,"effort":"max"}}')).toEqual({
+      reasoning: { enabled: true, effort: "max" },
+    });
+  });
+
+  it("parses JSON arrays", () => {
+    expect(parseParamValue("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  it("parses boolean literals", () => {
+    expect(parseParamValue("true")).toBe(true);
+    expect(parseParamValue("false")).toBe(false);
+  });
+
+  it("parses numbers", () => {
+    expect(parseParamValue("8192")).toBe(8192);
+    expect(parseParamValue("0")).toBe(0);
+  });
+
+  it("keeps plain strings as strings", () => {
+    expect(parseParamValue("hello")).toBe("hello");
+    expect(parseParamValue("sk-abc123")).toBe("sk-abc123");
+  });
+
+  it("keeps malformed JSON as the raw string", () => {
+    expect(parseParamValue("{placeholder}")).toBe("{placeholder}");
+  });
+
+  it("treats empty string as empty string, not zero", () => {
+    expect(parseParamValue("")).toBe("");
+  });
+
+  it("round-trips nested objects through formatParamValue", () => {
+    const v = parseParamValue('{"reasoning":{"enabled":true}}');
+    expect(formatParamValue(v)).toBe('{"reasoning":{"enabled":true}}');
+    expect(formatParamValue("hello")).toBe("hello");
+    expect(formatParamValue(true)).toBe("true");
+  });
+});

--- a/packages/ui/src/components/Providers.tsx
+++ b/packages/ui/src/components/Providers.tsx
@@ -29,6 +29,7 @@ import { Combobox } from "@/components/ui/combobox";
 import { ComboInput } from "@/components/ui/combo-input";
 import { api } from "@/lib/api";
 import { getConfiguredProxyUrl, isGlobalProxyEnabled } from "@/utils/proxy";
+import { parseParamValue, formatParamValue } from "@/utils/params";
 import { Toast } from "@/components/ui/toast";
 import type { Provider, ProviderHealthState, ProviderProbeTelemetry, ProviderQuotaUsage } from "@/types";
 
@@ -596,22 +597,24 @@ export function Providers() {
         if (transformerArray.length > 1 && typeof transformerArray[1] === 'object' && transformerArray[1] !== null) {
           // Update the existing parameters object
           const existingParams = transformerArray[1] as Record<string, unknown>;
-          const paramsObj: Record<string, unknown> = { ...existingParams, [paramName]: paramValue };
+          // Parse JSON/boolean/number literals so nested objects survive the
+          // round trip to config.json (a raw string would not deep-merge).
+          const paramsObj: Record<string, unknown> = { ...existingParams, [paramName]: parseParamValue(paramValue) };
           transformerArray[1] = paramsObj;
         } else if (transformerArray.length > 1) {
           // If there are other elements, add the parameters object
-          const paramsObj = { [paramName]: paramValue };
+          const paramsObj = { [paramName]: parseParamValue(paramValue) };
           transformerArray.splice(1, transformerArray.length - 1, paramsObj);
         } else {
           // Add a new parameters object
-          const paramsObj = { [paramName]: paramValue };
+          const paramsObj = { [paramName]: parseParamValue(paramValue) };
           transformerArray.push(paramsObj);
         }
         
         updatedProvider.transformer.use[transformerIndex] = transformerArray as string | (string | Record<string, unknown> | { max_tokens: number })[];
       } else {
         // Convert to array format with parameters
-        const paramsObj = { [paramName]: paramValue };
+        const paramsObj = { [paramName]: parseParamValue(paramValue) };
         updatedProvider.transformer.use[transformerIndex] = [targetTransformer as string, paramsObj];
       }
     }
@@ -674,22 +677,24 @@ export function Providers() {
         if (transformerArray.length > 1 && typeof transformerArray[1] === 'object' && transformerArray[1] !== null) {
           // Update the existing parameters object
           const existingParams = transformerArray[1] as Record<string, unknown>;
-          const paramsObj: Record<string, unknown> = { ...existingParams, [paramName]: paramValue };
+          // Parse JSON/boolean/number literals so nested objects survive the
+          // round trip to config.json (a raw string would not deep-merge).
+          const paramsObj: Record<string, unknown> = { ...existingParams, [paramName]: parseParamValue(paramValue) };
           transformerArray[1] = paramsObj;
         } else if (transformerArray.length > 1) {
           // If there are other elements, add the parameters object
-          const paramsObj = { [paramName]: paramValue };
+          const paramsObj = { [paramName]: parseParamValue(paramValue) };
           transformerArray.splice(1, transformerArray.length - 1, paramsObj);
         } else {
           // Add a new parameters object
-          const paramsObj = { [paramName]: paramValue };
+          const paramsObj = { [paramName]: parseParamValue(paramValue) };
           transformerArray.push(paramsObj);
         }
         
         updatedProvider.transformer[model].use[transformerIndex] = transformerArray as string | (string | Record<string, unknown> | { max_tokens: number })[];
       } else {
         // Convert to array format with parameters
-        const paramsObj = { [paramName]: paramValue };
+        const paramsObj = { [paramName]: parseParamValue(paramValue) };
         updatedProvider.transformer[model].use[transformerIndex] = [targetTransformer as string, paramsObj];
       }
     }
@@ -1329,7 +1334,7 @@ export function Providers() {
                                   {Object.entries(params).map(([key, value]) => (
                                     <div key={key} className="flex items-center justify-between bg-gray-50 rounded p-2">
                                       <div className="text-sm">
-                                        <span className="font-medium">{key}:</span> {String(value)}
+                                        <span className="font-medium">{key}:</span> {formatParamValue(value)}
                                       </div>
                                       <Button 
                                         variant="ghost" 
@@ -1483,7 +1488,7 @@ export function Providers() {
                                           {Object.entries(params).map(([key, value]) => (
                                             <div key={key} className="flex items-center justify-between bg-gray-50 rounded p-2">
                                               <div className="text-sm">
-                                                <span className="font-medium">{key}:</span> {String(value)}
+                                                <span className="font-medium">{key}:</span> {formatParamValue(value)}
                                               </div>
                                               <Button 
                                                 variant="ghost" 

--- a/packages/ui/src/utils/params.ts
+++ b/packages/ui/src/utils/params.ts
@@ -1,0 +1,40 @@
+/**
+ * Parse a transformer parameter value entered in the UI into the type the
+ * transformer actually expects. JSON objects/arrays (e.g.
+ * `{"reasoning":{"enabled":true,"effort":"max"}}`) become real objects;
+ * boolean and number literals become real booleans/numbers; anything else
+ * stays a plain string.
+ */
+export function parseParamValue(value: string): unknown {
+  const trimmed = value.trim();
+
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+
+  if (trimmed !== "" && !Number.isNaN(Number(trimmed))) {
+    return Number(trimmed);
+  }
+
+  // Only treat as JSON when it clearly starts an object/array — otherwise a
+  // value like `{placeholder}` would surface a confusing parse error.
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // Malformed JSON — keep the raw string so the user can fix it and the
+      // config never becomes silently invalid.
+      return value;
+    }
+  }
+
+  return value;
+}
+
+/**
+ * Format a stored parameter value back into the text shown in the UI input.
+ */
+export function formatParamValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  return JSON.stringify(value);
+}


### PR DESCRIPTION
## Problem

Transformer parameter values entered in the Providers UI were always stored as strings. Structured values therefore could not be configured from the UI at all:

- Entering `{"reasoning":{"enabled":true,"effort":"max"}}` as a parameter value produced a **string** value in config.json.
- `CustomParamsTransformer` deep-merges only object values; an existing object field (e.g. `reasoning: {enabled:false}` produced by `AnthropicTransformer` for disabled thinking) is kept and the string parameter is ignored.
- Net effect: a mandatory-reasoning endpoint like OpenRouter `stealth/ox-alpha` kept returning 400 "Reasoning is mandatory for this endpoint and cannot be disabled." even after being "configured" in the UI — while a hand-edited config.json with a real nested object worked.

Additionally, existing non-string parameter values rendered as `[object Object]` in the parameters list.

## Fix

- New `packages/ui/src/utils/params.ts`:
  - `parseParamValue`: `true`/`false` → boolean; numeric literals → number; input starting with `{` or `[` → `JSON.parse` (**malformed JSON keeps the raw string**, so a typo never silently corrupts config.json); anything else stays a string; empty string stays empty (not 0).
  - `formatParamValue`: renders stored objects/booleans back to text for display and round-tripping.
- Applied `parseParamValue` in all transformer-parameter write paths — provider-level (`addProviderTransformerParameter`, 4 branches) and model-level (`addModelTransformerParameter`, same duplicated pattern).
- Parameter display now uses `formatParamValue` instead of `String(value)`.

## Verification

- New unit tests (`ui-params.test.ts`, run in the core suite): nested JSON, arrays, booleans, numbers, plain strings, malformed JSON passthrough, empty-string guard, format round-trip — 8/8 passing.
- Full core suite: 22 files / 237 tests passing.
- UI `tsc -b` clean; production UI build succeeds.

Note: this fixes value parsing only. The separate stale-snapshot overwrite issue (an open edit dialog holding an old provider snapshot can clobber externally changed config on save) is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)